### PR TITLE
Add 'six' to requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     url='https://github.com/clarifai/clarifai_py',
     author_email='support@clarifai.com',
     version='0.2',
-    install_requires=[],
+    install_requires=['six'],
     namespace_packages=['clarifai'],
     packages=['clarifai.client'],
     scripts=[],


### PR DESCRIPTION
A user reported issues importing the client because he didn't have the
'six' module installed. I added this to the install requirements in
setup.py.