### PR TITLE
Better handle JSONDecodeError when not receiving token

### DIFF
--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -3272,7 +3272,10 @@ class ApiClient(object):
       self.token = res.json()['access_token']
       self.headers = {'Authorization': "Bearer %s" % self.token}
     else:
-      raise TokenError("Could not get a new token for v2: %s", str(res.json()))
+      try:
+        raise TokenError("Could not get a new token for v2: %s", str(res.json()))
+      except ValueError:
+        raise TokenError("Could not get a new token for v2: %s", str(res.content))
     return res.json()
 
   def set_token(self, token):


### PR DESCRIPTION
Here's a stack trace of a crash in one of my applications:
```
[Some local code]
  File "/home/myuser/.local/share/virtualenvs/myvenv/local/lib/python2.7/site-packages/clarifai/rest/client.py", line 3309, in get_token
    raise TokenError("Could not get a new token for v2: %s", str(res.json()))
  File "/home/myuser/.local/share/virtualenvs/myvenv/local/lib/python2.7/site-packages/requests/models.py", line 892, in json
    return complexjson.loads(self.text, **kwargs)
  File "/home/myuser/.local/share/virtualenvs/myvenv/local/lib/python2.7/site-packages/simplejson/__init__.py", line 516, in loads
    return _default_decoder.decode(s)
  File "/home/myuser/.local/share/virtualenvs/myvenv/local/lib/python2.7/site-packages/simplejson/decoder.py", line 370, in decode
    obj, end = self.raw_decode(s)
  File "/home/myuser/.local/share/virtualenvs/myvenv/local/lib/python2.7/site-packages/simplejson/decoder.py", line 400, in raw_decode
    return self.scan_once(s, idx=_w(s, idx).end())
JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

I just wrapped the `raise TokenError` to fail in a more graceful manner.