### PR TITLE
Hard code protobuf version to 2.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ future>=0.15, <2
 googleapis-common-protos>=1.5.0, <2
 grpcio>=1.13.0, <2
 jsonschema>=2.5, <3
-protobuf>=3.6, <4
+protobuf==3.6.1
 requests>=2.13, <3
 typing>=3.6


### PR DESCRIPTION
Protobuf 3.7.0 was released and changed the init signature for _Parser, which is subclassed for _CustomParser.

This is a work around until we can get a more finalized solution in place.