### PR TITLE
[TT-544]: remove Face object and facedetect* model types

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,33 @@
 [settings]
-line_length=100
+line_length=99
 
 # Ignore differences in whitespace.
 ignore_whitespace=True
+
+known_third_party=
+    grpc,
+    yaml,
+    cached_property,
+    lap,
+    magic,
+    PIL,
+    pydub,
+    google,
+    mock,
+    requests,
+    googleapiclient,
+    oauth2client,
+    dns,
+    noise,
+    urllib3,
+    simplejson,
+    imageio,
+    retrying,
+    json_lines
+
+
+# isort being dumb
+known_future_library=
+    future,
+    six,
+    past

--- a/clarifai/rest/__init__.py
+++ b/clarifai/rest/__init__.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from clarifai.errors import ApiError, TokenError, UserError
-from clarifai.rest.client import (
-    GENERAL_MODEL_ID, ApiClient, ApiStatus, BoundingBox, ClarifaiApp, Concept, Face,
-    FaceAgeAppearance, FaceGenderAppearance, FaceIdentity, FaceMulticulturalAppearance, Geo,
-    GeoBox, GeoLimit, GeoPoint, Image, InputSearchTerm, Model, ModelOutputConfig, ModelOutputInfo,
-    OutputSearchTerm, Region, RegionInfo, SearchQueryBuilder, Video, Workflow)
+from clarifai.rest.client import (GENERAL_MODEL_ID, ApiClient, ApiStatus, BoundingBox, ClarifaiApp,
+                                  Concept, Geo, GeoBox, GeoLimit, GeoPoint, Image, InputSearchTerm,
+                                  Model, ModelOutputConfig, ModelOutputInfo, OutputSearchTerm,
+                                  Region, RegionInfo, SearchQueryBuilder, Video, Workflow)
 
 # So autoflake doesn't remove imports.
 _ = ApiError

--- a/tests/rest_tests/test_models.py
+++ b/tests/rest_tests/test_models.py
@@ -659,13 +659,13 @@ class TestModels(unittest.TestCase):
     self.app.models.clear_model_cache()
     self.assertFalse(self.app.models.model_id_cache)
 
-    model = self.app.models.get('face')
+    model = self.app.models.get('moderation')
 
     self.assertTrue(self.app.models.model_id_cache)
-    self.assertTrue(self.app.models.model_id_cache.get('face', 'facedetect'))
+    self.assertTrue(self.app.models.model_id_cache.get('moderation', 'concept'))
 
-    model2 = self.app.models.get('face', model_type='embed')
-    self.assertTrue(self.app.models.model_id_cache.get('face', 'embed'))
+    model2 = self.app.models.get('general', model_type='embed')
+    self.assertTrue(self.app.models.model_id_cache.get('general', 'embed'))
     self.assertNotEqual(model.model_id, model2.model_id)
 
     model3 = self.app.models.get(model_id=GENERAL_MODEL_ID)

--- a/tests/unit_tests/test_inputs.py
+++ b/tests/unit_tests/test_inputs.py
@@ -2,8 +2,8 @@ import mock
 import pytest
 
 from clarifai.errors import ApiError, UserError
-from clarifai.rest import (BoundingBox, ClarifaiApp, Concept, Face, FaceIdentity, Geo, GeoPoint,
-                           Image, Region, RegionInfo)
+from clarifai.rest import (BoundingBox, ClarifaiApp, Concept, Geo, GeoPoint, Image, Region,
+                           RegionInfo)
 
 from .mock_extensions import (assert_request, assert_requests, mock_request,
                               mock_request_with_failed_response)

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -84,7 +84,7 @@ def test_create_model(mock_http_client):  # type: (mock.Mock) -> None
       "output_config": {}
     }
   }
-} 
+}
       """)
 
 
@@ -185,8 +185,8 @@ def test_get_all_models(mock_http_client):  # type: (mock.Mock) -> None
       "app_id": "main",
       "output_info": {
         "message": "Show output_info with: GET /models/{model_id}/output_info",
-        "type": "facedetect",
-        "type_ext": "facedetect"
+        "type": "detect",
+        "type_ext": "detect"
       },
       "model_version": {
         "id": "28b2ff6148684aa2b18a34cd004b4fac",
@@ -238,7 +238,7 @@ def test_get_all_models(mock_http_client):  # type: (mock.Mock) -> None
 
   assert models[0].model_id == '@modelID1'
   assert models[0].model_name == '@modelName1'
-  assert models[0].output_info['type_ext'] == 'facedetect'
+  assert models[0].output_info['type_ext'] == 'detect'
 
   assert models[1].model_id == '@modelID2'
   assert models[1].model_name == '@modelName2'
@@ -415,7 +415,7 @@ def test_update_model(mock_http_client):  # type: (mock.Mock) -> None
     }
   ],
   "action": "merge"
-} 
+}
 """)
 
   # User Error should be thrown if unsupported action is given
@@ -458,7 +458,7 @@ def test_train_model(mock_http_client):  # type: (mock.Mock) -> None
       "train_stats": {}
     }
   }
-} 
+}
   """)
 
   app = ClarifaiApp()

--- a/tests/unit_tests/test_search_models.py
+++ b/tests/unit_tests/test_search_models.py
@@ -10,38 +10,43 @@ TINY_IMAGE_BASE64 = b'R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw
 @mock.patch('clarifai.rest.http_client.HttpClient')
 def test_search_models_by_name(mock_http_client):  # type: (mock.Mock) -> None
   mock_execute_request = mock_request(mock_http_client, """
+
 {
-  "status": {
-    "code": 10000,
-    "description": "Ok"
-  },
-  "models": [{
-    "id": "@modelID",
-    "name": "celeb-v1.3",
-    "created_at": "2016-10-25T19:30:38.541073Z",
-    "app_id": "main",
-    "output_info": {
-      "message": "Show output_info with: GET /models/{model_id}/output_info",
-      "type": "concept",
-      "type_ext": "facedetect-identity"
+    "status": {
+        "code": 10000,
+        "description": "Ok",
+        "req_id": "08e649a6116f4f56992e1676b25dcde6"
     },
-    "model_version": {
-      "id": "@modelVersionID",
-      "created_at": "2016-10-25T19:30:38.541073Z",
-      "status": {
-        "code": 21100,
-        "description": "Model trained successfully"
-      },
-      "active_concept_count": 10554
-    },
-    "display_name": "Celebrity"
-  }]
+    "models": [
+        {
+            "id": "@modelID",
+            "name": "moderation",
+            "created_at": "2017-05-12T21:28:00.471607Z",
+            "app_id": "main",
+            "output_info": {
+                "message": "Show output_info with: GET /models/{model_id}/output_info",
+                "type": "concept",
+                "type_ext": "concept"
+            },
+            "model_version": {
+                "id": "@modelVersionID",
+                "created_at": "2017-10-26T20:29:09.263232Z",
+                "status": {
+                    "code": 21100,
+                    "description": "Model is trained and ready"
+                },
+                "active_concept_count": 5,
+                "worker_id": "8b7c05a25ce04d0490367390665f1526"
+            },
+            "display_name": "Moderation"
+        }
+    ]
 }
 """)
 
   app = ClarifaiApp()
 
-  models = app.models.search("celeb*")
+  models = app.models.search("moderation*")
 
   assert models[0].model_id == '@modelID'
   assert models[0].model_version == '@modelVersionID'
@@ -49,7 +54,7 @@ def test_search_models_by_name(mock_http_client):  # type: (mock.Mock) -> None
   assert_request(mock_execute_request, 'POST', '/v2/models/searches', """
 {
   "model_query": {
-    "name": "celeb*"
+    "name": "moderation*"
   }
 }
   """)


### PR DESCRIPTION
These will be deprecated in coming week. See https://docs.clarifai.com/product-updates/upcoming-api-changes for more details on the Face proto deprecation and the `facedetect*` model type cleanup.