### PR TITLE
check concept ids before deleting concept

### DIFF
--- a/tests/rest_tests/test_models.py
+++ b/tests/rest_tests/test_models.py
@@ -563,6 +563,7 @@ class TestModels(unittest.TestCase):
 
     model_id = uuid.uuid4().hex
     model = self.app.models.create(model_id)
+    time.sleep(1)
     model.add_concepts(['cats4', 'dogs4'])
     model.delete_concepts(['cats4'])
     model.merge_concepts(['cats4', 'dogs4'])
@@ -585,6 +586,7 @@ class TestModels(unittest.TestCase):
 
     model_id = uuid.uuid4().hex
     model = self.app.models.create(model_id)
+    time.sleep(1)
     model = model.merge_concepts(concept_ids=['cats5', 'dogs5'])
     model = model.delete_concepts(concept_ids=['dogs5'])
 

--- a/tests/rest_tests/test_models.py
+++ b/tests/rest_tests/test_models.py
@@ -475,6 +475,7 @@ class TestModels(unittest.TestCase):
 
     model_id = uuid.uuid4().hex
     model = self.app.models.create(model_id)
+    time.sleep(1)
     model.add_concepts(['cats3', 'dogs3'])
 
     # mock the response of res_ver = self.api.get_model_version(model_id, model_version)


### PR DESCRIPTION
In the integration test, check the concepts ids before deleting a concept.
"delete_concept" will failed on "The existing model does not have tags to remove", which should NOT happen after a successful "add_concept" call.