### PR TITLE
Use environment markers for conditional dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,9 @@
-import sys
-
 from setuptools import find_packages
 
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
-
-has_enum = sys.version_info >= (3, 4)
-has_typing = sys.version_info >= (3, 5)
 
 setup(
     name="clarifai",
@@ -25,9 +20,9 @@ setup(
                       'jsonschema>=2.5, <3',
                       'grpcio>=1.13.0, <2',
                       'protobuf>=3.6, <4',
-                      'googleapis-common-protos>=1.5.0, <2'] +
-                     ([] if has_enum else ['enum34>=1.1, <2']) +
-                     ([] if has_typing else ['typing>=3.6']),
+                      'googleapis-common-protos>=1.5.0, <2',
+                      'enum34>=1.1, <2;python_version<"3.5"',
+                      'typing>=3.6;python_version<"3.6"'],
     packages=find_packages(),
     license="Apache 2.0",
     scripts=['scripts/clarifai'],


### PR DESCRIPTION
See: https://www.python.org/dev/peps/pep-0508/#environment-markers

This fixes package installation with package managers like Poetry.