### PR TITLE
fix invalid api key test

### DIFF
--- a/tests/rest_tests/test_api.py
+++ b/tests/rest_tests/test_api.py
@@ -6,7 +6,6 @@ import time
 import unittest
 
 import responses
-
 from clarifai.rest import ApiClient, ApiError, ClarifaiApp
 
 from . import sample_inputs
@@ -246,9 +245,12 @@ class TestApiExceptions(unittest.TestCase):
 
   def test_invalid_api_key_error(self):
     with self.assertRaises(ApiError) as ex:
-      ClarifaiApp(api_key='some-invalid-api-key')
-
+      ClarifaiApp(api_key='invalid-api-key-format')
     raised_exception = ex.exception
+    assert raised_exception.error_code == 11008
 
+    with self.assertRaises(ApiError) as ex:
+      ClarifaiApp(api_key='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+    raised_exception = ex.exception
     assert raised_exception.error_code == 11009
     assert raised_exception.error_desc == 'API key not found'

--- a/tests/rest_tests/test_api.py
+++ b/tests/rest_tests/test_api.py
@@ -244,10 +244,11 @@ class TestApiExceptions(unittest.TestCase):
       app.public_models.general_model.predict_by_url(sample_inputs.METRO_IMAGE_URL)
 
   def test_invalid_api_key_error(self):
-    with self.assertRaises(ApiError) as ex:
-      ClarifaiApp(api_key='invalid-api-key-format')
-    raised_exception = ex.exception
-    assert raised_exception.error_code == 11008
+    # [FIXME] uncomment this when invalid-key-format PR is in prod.
+    # with self.assertRaises(ApiError) as ex:
+    #   ClarifaiApp(api_key='invalid-api-key-format')
+    # raised_exception = ex.exception
+    # assert raised_exception.error_code == 11008
 
     with self.assertRaises(ApiError) as ex:
       ClarifaiApp(api_key='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')


### PR DESCRIPTION
Currently in backend, we strictly limit the API Key to be 32 character length hex encoded string.
So, update the client test to reflect this limitation.