### PR TITLE
shift frame time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,20 @@ matrix:
       python: '3.8'
     - os: osx
       language: generic
-      env: PYTHON=3.5.6
-    - os: osx
-      language: generic
       env:
-        - PYTHON=3.8.2
+        - PYTHON=3.5.6
         - RELEASE_JOB=true
+# In recent versions of pip, there's an issue with the typing package on
+# the latest Python versions (apparently on osx only?). See more here:
+# https://stackoverflow.com/questions/55833509/attributeerror-type-object-callable-has-no-attribute-abc-registry
+#
+# Once the above is fixed, uncomment the environment below, and remove RELEASE_JOB above.
+#
+#    - os: osx
+#      language: generic
+#      env:
+#        - PYTHON=3.8.2
+#        - RELEASE_JOB=true
 
 # environmental variables
 env:

--- a/tests/rest_tests/test_video.py
+++ b/tests/rest_tests/test_video.py
@@ -138,7 +138,7 @@ class TestVideo(unittest.TestCase):
     res = m.predict_by_url(sample_inputs.BEER_VIDEO_URL, is_video=True, sample_ms=2000)
     self._verify_video_response(res)
     for frame in res['outputs'][0]['data']['frames']:
-      assert frame['frame_info']['time'] % 2000 == 0
+      assert frame['frame_info']['time'] % 1000 == 0
 
   def test_predict_video_filename_with_custom_sample_ms(self):
     """ test video with not just general models """
@@ -147,7 +147,7 @@ class TestVideo(unittest.TestCase):
     res = m.predict_by_filename(sample_inputs.BEER_VIDEO_FILE_PATH, is_video=True, sample_ms=2000)
     self._verify_video_response(res)
     for frame in res['outputs'][0]['data']['frames']:
-      assert frame['frame_info']['time'] % 2000 == 0
+      assert frame['frame_info']['time'] % 1000 == 0
 
   def test_predict_video_bytes_with_custom_sample_ms(self):
     """ test video with not just general models """
@@ -157,7 +157,7 @@ class TestVideo(unittest.TestCase):
     res = m.predict_by_bytes(file_bytes, is_video=True, sample_ms=2000)
     self._verify_video_response(res)
     for frame in res['outputs'][0]['data']['frames']:
-      assert frame['frame_info']['time'] % 2000 == 0
+      assert frame['frame_info']['time'] % 1000 == 0
 
   def test_predict_video_base64_with_custom_sample_ms(self):
     """ test video with not just general models """
@@ -167,4 +167,4 @@ class TestVideo(unittest.TestCase):
     res = m.predict_by_base64(base64.encodestring(file_bytes), is_video=True, sample_ms=2000)
     self._verify_video_response(res)
     for frame in res['outputs'][0]['data']['frames']:
-      assert frame['frame_info']['time'] % 2000 == 0
+      assert frame['frame_info']['time'] % 1000 == 0

--- a/tests/rest_tests/test_video.py
+++ b/tests/rest_tests/test_video.py
@@ -138,7 +138,8 @@ class TestVideo(unittest.TestCase):
     res = m.predict_by_url(sample_inputs.BEER_VIDEO_URL, is_video=True, sample_ms=2000)
     self._verify_video_response(res)
     for frame in res['outputs'][0]['data']['frames']:
-      assert (frame['frame_info']['time']+1000) % 2000 == 0 # API will return 1000/3000/5000... midpint timestamp
+      assert (frame['frame_info']['time'] + 1000
+             ) % 2000 == 0  # API will return 1000/3000/5000... midpint timestamp
 
   def test_predict_video_filename_with_custom_sample_ms(self):
     """ test video with not just general models """
@@ -147,7 +148,8 @@ class TestVideo(unittest.TestCase):
     res = m.predict_by_filename(sample_inputs.BEER_VIDEO_FILE_PATH, is_video=True, sample_ms=2000)
     self._verify_video_response(res)
     for frame in res['outputs'][0]['data']['frames']:
-      assert (frame['frame_info']['time']+1000) % 2000 == 0 # API will return 1000/3000/5000... midpint timestamp
+      assert (frame['frame_info']['time'] + 1000
+             ) % 2000 == 0  # API will return 1000/3000/5000... midpint timestamp
 
   def test_predict_video_bytes_with_custom_sample_ms(self):
     """ test video with not just general models """
@@ -157,7 +159,8 @@ class TestVideo(unittest.TestCase):
     res = m.predict_by_bytes(file_bytes, is_video=True, sample_ms=2000)
     self._verify_video_response(res)
     for frame in res['outputs'][0]['data']['frames']:
-      assert (frame['frame_info']['time']+1000) % 2000 == 0 # API will return 1000/3000/5000... midpint timestamp
+      assert (frame['frame_info']['time'] + 1000
+             ) % 2000 == 0  # API will return 1000/3000/5000... midpint timestamp
 
   def test_predict_video_base64_with_custom_sample_ms(self):
     """ test video with not just general models """
@@ -167,4 +170,5 @@ class TestVideo(unittest.TestCase):
     res = m.predict_by_base64(base64.encodestring(file_bytes), is_video=True, sample_ms=2000)
     self._verify_video_response(res)
     for frame in res['outputs'][0]['data']['frames']:
-      assert (frame['frame_info']['time']+1000) % 2000 == 0 # API will return 1000/3000/5000... midpint timestamp
+      assert (frame['frame_info']['time'] + 1000
+             ) % 2000 == 0  # API will return 1000/3000/5000... midpint timestamp

--- a/tests/rest_tests/test_video.py
+++ b/tests/rest_tests/test_video.py
@@ -138,7 +138,7 @@ class TestVideo(unittest.TestCase):
     res = m.predict_by_url(sample_inputs.BEER_VIDEO_URL, is_video=True, sample_ms=2000)
     self._verify_video_response(res)
     for frame in res['outputs'][0]['data']['frames']:
-      assert (frame['frame_info']['time']-1000) % 2000 == 0 # API will return 1000/3000/5000... midpint timestamp
+      assert (frame['frame_info']['time']+1000) % 2000 == 0 # API will return 1000/3000/5000... midpint timestamp
 
   def test_predict_video_filename_with_custom_sample_ms(self):
     """ test video with not just general models """
@@ -147,7 +147,7 @@ class TestVideo(unittest.TestCase):
     res = m.predict_by_filename(sample_inputs.BEER_VIDEO_FILE_PATH, is_video=True, sample_ms=2000)
     self._verify_video_response(res)
     for frame in res['outputs'][0]['data']['frames']:
-      assert (frame['frame_info']['time']-1000) % 2000 == 0 # API will return 1000/3000/5000... midpint timestamp
+      assert (frame['frame_info']['time']+1000) % 2000 == 0 # API will return 1000/3000/5000... midpint timestamp
 
   def test_predict_video_bytes_with_custom_sample_ms(self):
     """ test video with not just general models """
@@ -157,7 +157,7 @@ class TestVideo(unittest.TestCase):
     res = m.predict_by_bytes(file_bytes, is_video=True, sample_ms=2000)
     self._verify_video_response(res)
     for frame in res['outputs'][0]['data']['frames']:
-      assert (frame['frame_info']['time']-1000) % 2000 == 0 # API will return 1000/3000/5000... midpint timestamp
+      assert (frame['frame_info']['time']+1000) % 2000 == 0 # API will return 1000/3000/5000... midpint timestamp
 
   def test_predict_video_base64_with_custom_sample_ms(self):
     """ test video with not just general models """
@@ -167,4 +167,4 @@ class TestVideo(unittest.TestCase):
     res = m.predict_by_base64(base64.encodestring(file_bytes), is_video=True, sample_ms=2000)
     self._verify_video_response(res)
     for frame in res['outputs'][0]['data']['frames']:
-      assert (frame['frame_info']['time']-1000) % 2000 == 0 # API will return 1000/3000/5000... midpint timestamp
+      assert (frame['frame_info']['time']+1000) % 2000 == 0 # API will return 1000/3000/5000... midpint timestamp

--- a/tests/rest_tests/test_video.py
+++ b/tests/rest_tests/test_video.py
@@ -138,7 +138,7 @@ class TestVideo(unittest.TestCase):
     res = m.predict_by_url(sample_inputs.BEER_VIDEO_URL, is_video=True, sample_ms=2000)
     self._verify_video_response(res)
     for frame in res['outputs'][0]['data']['frames']:
-      assert frame['frame_info']['time'] % 1000 == 0
+      assert (frame['frame_info']['time']-1000) % 2000 == 0 # API will return 1000/3000/5000... midpint timestamp
 
   def test_predict_video_filename_with_custom_sample_ms(self):
     """ test video with not just general models """
@@ -147,7 +147,7 @@ class TestVideo(unittest.TestCase):
     res = m.predict_by_filename(sample_inputs.BEER_VIDEO_FILE_PATH, is_video=True, sample_ms=2000)
     self._verify_video_response(res)
     for frame in res['outputs'][0]['data']['frames']:
-      assert frame['frame_info']['time'] % 1000 == 0
+      assert (frame['frame_info']['time']-1000) % 2000 == 0 # API will return 1000/3000/5000... midpint timestamp
 
   def test_predict_video_bytes_with_custom_sample_ms(self):
     """ test video with not just general models """
@@ -157,7 +157,7 @@ class TestVideo(unittest.TestCase):
     res = m.predict_by_bytes(file_bytes, is_video=True, sample_ms=2000)
     self._verify_video_response(res)
     for frame in res['outputs'][0]['data']['frames']:
-      assert frame['frame_info']['time'] % 1000 == 0
+      assert (frame['frame_info']['time']-1000) % 2000 == 0 # API will return 1000/3000/5000... midpint timestamp
 
   def test_predict_video_base64_with_custom_sample_ms(self):
     """ test video with not just general models """
@@ -167,4 +167,4 @@ class TestVideo(unittest.TestCase):
     res = m.predict_by_base64(base64.encodestring(file_bytes), is_video=True, sample_ms=2000)
     self._verify_video_response(res)
     for frame in res['outputs'][0]['data']['frames']:
-      assert frame['frame_info']['time'] % 1000 == 0
+      assert (frame['frame_info']['time']-1000) % 2000 == 0 # API will return 1000/3000/5000... midpint timestamp


### PR DESCRIPTION
video frame timestamp will be midpoint time.
for example when sample_ms is 2000,
previously we return the frame time as:
0s, 2s, 4s ...
now we change to:
1s, 3s, 5s....
Making this change so the time is more accurate since ffmpeg using the midpoint.