### PR TITLE
Fix empty model type parser

### DIFF
--- a/clarifai/rest/client.py
+++ b/clarifai/rest/client.py
@@ -1040,7 +1040,7 @@ class Models(object):
     try:
       for m in models:
         model_name = m.model_name
-        model_type = m.output_info['type']
+        model_type = m.output_info.get('type')
         model_id = m.model_id
         model_cache.update({(model_name, model_type): model_id})
     except ApiError as e:


### PR DESCRIPTION
I've encountered an error while using the lib last time with both python 3.7 & 3.9

```
Traceback (most recent call last):
   app = ClarifaiApp(api_key=clarifai_token)
  File "python3.7/site-packages/clarifai/rest/client.py", line 124, in __init__
    self.models = Models(self.api, self.solutions)  # type: Models
  File "python3.7/site-packages/clarifai/rest/client.py", line 1068, in __init__
    self.model_id_cache = self.init_model_cache()
  File "python3.7/site-packages/clarifai/rest/client.py", line 1090, in init_model_cache
    model_type = m.output_info['type']
KeyError: 'type'
```

Dived deeper and found that some model does not return a type
- Good model
```
{'message': 'Show output_info with: GET /models/{model_id}/output_info',
 'output_config': {'closed_environment': False,
                   'concepts_mutually_exclusive': False,
                   'max_concepts': 0,
                   'min_value': 0.0},
 **'type': 'detect-concept',**
 'type_ext': 'detect-concept'}
```

- Bad model (ner_english id: 3a4dd3157b18d37f3402cdaca8091ddd)
```
{'message': 'Show output_info with: GET /models/{model_id}/output_info',
 'output_config': {'closed_environment': False,
                   'concepts_mutually_exclusive': False,
                   'max_concepts': 0,
                   'min_value': 0.0}}
```

P.S: I know this lib is not maintained already, but it would be nice to share a bug & fix with community 😄 