### PR TITLE
🐛 Fix dataset export image format

### DIFF
--- a/clarifai/datasets/export/dataset_inputs.py
+++ b/clarifai/datasets/export/dataset_inputs.py
@@ -107,7 +107,7 @@ class InputDownloader:
     self.num_inputs = 0
     self.split_prefix = None
     self.session = session
-    self.input_ext = dict(image=".jpg", text=".txt", audio=".mp3", video=".mp4")
+    self.input_ext = dict(image=".png", text=".txt", audio=".mp3", video=".mp4")
     if isinstance(self.input_iterator, DatasetExportReader):
       self.split_prefix = self.input_iterator.split_dir
 
@@ -118,7 +118,7 @@ class InputDownloader:
     p.feed(self.session.get(hosted_url).content)
     image = p.close()
     image_file = BytesIO()
-    image.save(image_file, 'JPEG')
+    image.save(image_file, 'PNG')
     new_archive.writestr(file_name, image_file.getvalue())
 
   def _save_text_to_archive(self, new_archive: zipfile.ZipFile, hosted_url: str,


### PR DESCRIPTION
**Problem**

When using `clarifai.datasets.export.dataset_inputs.InputDownloader` on a local archive with image URLs, the following error is raised:
> OSError: cannot write mode RGBA as JPEG

[This](https://stackoverflow.com/questions/48248405/cannot-write-mode-rgba-as-jpeg) slackoverflow post proposes to use something like PNG instead to account for the A (transparency) channel of the images.

**Tests**

Locally tested and passing. To replicate, create a dataset version export (protobuf) and run the following snippet:
```python
import requests

from clarifai.datasets.export.dataset_inputs import DatasetExportReader, InputDownloader

metadata = 'Key API_KEY'

def main():
    local_archive_path = "FULL_PATH_TO_ZIP"
    save_path = "output.zip"
    # Create a session object and set auth header
    session = requests.Session()
    session.headers.update({'Authorization': metadata})

    with DatasetExportReader(session=session, local_archive_path=local_archive_path) as reader:
        InputDownloader(session, reader).download_input_archive(save_path=save_path)


if __name__ == '__main__':
    main()
```