### PR TITLE
Add inference params Support in Model Predict

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,19 +141,19 @@ print(gpt_4_model)
 
 
 # Model Predict
-model_prediction = Model("https://clarifai.com/anthropic/completion/models/claude-v2").predict_by_bytes(b"Write a tweet on future of AI")
+model_prediction = Model("https://clarifai.com/anthropic/completion/models/claude-v2").predict_by_bytes(b"Write a tweet on future of AI", input_type="text")
 
 # Customizing Model Inference Output
-model_prediction = gpt_4_model.predict_by_bytes(b"Write a tweet on future of AI", inference_params=dict(temperature=str(0.7), max_tokens=30))
+model_prediction = gpt_4_model.predict_by_bytes(b"Write a tweet on future of AI", "text", inference_params=dict(temperature=str(0.7), max_tokens=30))
 # Return predictions having prediction confidence > 0.98
-model_prediction = model.predict_by_filepath(filepath="local_filepath", output_config={"min_value": 0.98}) # Supports image, text, audio, video
+model_prediction = model.predict_by_filepath(filepath="local_filepath", input_type, output_config={"min_value": 0.98}) # Supports image, text, audio, video
 
 # Supports prediction by url
-model_prediction = model.predict_by_url(url="url") # Supports image, text, audio, video
+model_prediction = model.predict_by_url(url="url", input_type) # Supports image, text, audio, video
 
 # Return predictions for specified interval of video
 video_input_proto = [input_obj.get_input_from_url("Input_id", video_url=BEER_VIDEO_URL)]
-model_prediction = model.predict(video_input_proto, output_config={"sample_ms": 2000})
+model_prediction = model.predict(video_input_proto, input_type="video", output_config={"sample_ms": 2000})
 ```
 #### Models Listing
 ```python

--- a/README.md
+++ b/README.md
@@ -132,20 +132,28 @@ all_concepts = list(app.list_concepts())
 # Note: CLARIFAI_PAT must be set as env variable.
 from clarifai.client.model import Model
 
-# Model Predict
-model_prediction = Model("https://clarifai.com/anthropic/completion/models/claude-v2").predict_by_bytes(b"Write a tweet on future of AI", "text")
+"""
+Get Model information on details of model(description, usecases..etc) and info on training or
+# other inference parameters(eg: temperature, top_k, max_tokens..etc for LLMs)
+"""
+gpt_4_model = Model("https://clarifai.com/openai/chat-completion/models/GPT-4")
+print(gpt_4_model)
 
-model = Model(user_id="user_id", app_id="app_id", model_id="model_id")
-model_prediction = model.predict_by_url(url="url", input_type="image") # Supports image, text, audio, video
+
+# Model Predict
+model_prediction = Model("https://clarifai.com/anthropic/completion/models/claude-v2").predict_by_bytes(b"Write a tweet on future of AI")
 
 # Customizing Model Inference Output
-model = Model(user_id="user_id", app_id="app_id", model_id="model_id",
-                  output_config={"min_value": 0.98}) # Return predictions having prediction confidence > 0.98
-model_prediction = model.predict_by_filepath(filepath="local_filepath", input_type="text") # Supports image, text, audio, video
+model_prediction = gpt_4_model.predict_by_bytes(b"Write a tweet on future of AI", inference_params=dict(temperature=str(0.7), max_tokens=30))
+# Return predictions having prediction confidence > 0.98
+model_prediction = model.predict_by_filepath(filepath="local_filepath", output_config={"min_value": 0.98}) # Supports image, text, audio, video
 
-model = Model(user_id="user_id", app_id="app_id", model_id="model_id",
-                    output_config={"sample_ms": 2000}) # Return predictions for specified interval
-model_prediction = model.predict_by_url(url="VIDEO_URL", input_type="video")
+# Supports prediction by url
+model_prediction = model.predict_by_url(url="url") # Supports image, text, audio, video
+
+# Return predictions for specified interval of video
+video_input_proto = [input_obj.get_input_from_url("Input_id", video_url=BEER_VIDEO_URL)]
+model_prediction = model.predict(video_input_proto, output_config={"sample_ms": 2000})
 ```
 #### Models Listing
 ```python

--- a/clarifai/client/base.py
+++ b/clarifai/client/base.py
@@ -82,35 +82,22 @@ class BaseClient:
 
     return timestamp_obj
 
-  def process_response_keys(self, old_dict, listing_resource=None):
+  def process_response_keys(self, old_dict, listing_resource):
     """Converts keys in a response dictionary to resource proto format.
 
     Args:
         old_dict (dict): The dictionary to convert.
-        listing_resource (str): The resource type to convert to. Defaults to None.
 
     Returns:
         new_dict (dict): The dictionary with processed keys.
     """
-    if listing_resource:
-      old_dict[f'{listing_resource}_id'] = old_dict['id']
-      old_dict.pop('id')
+    old_dict[f'{listing_resource}_id'] = old_dict['id']
+    old_dict.pop('id')
 
     def convert_recursive(item):
       if isinstance(item, dict):
         new_item = {}
         for key, value in item.items():
-          if key == 'default_value':
-            # Map infer param value to proto value
-            value_map = dict(number_value=None, string_value=None, bool_value=None)
-
-            def map_fn(v):
-              return 'number_value' if isinstance(v, float) or isinstance(v, int) else \
-              'string_value' if isinstance(v, str) else \
-              'bool_value' if isinstance(v, bool) else None
-
-            value_map[map_fn(value)] = value
-            value = struct_pb2.Value(**value_map)
           if key in ['created_at', 'modified_at', 'completed_at']:
             value = self.convert_string_to_timestamp(value)
           elif key in ['workflow_recommended']:

--- a/clarifai/client/base.py
+++ b/clarifai/client/base.py
@@ -82,22 +82,35 @@ class BaseClient:
 
     return timestamp_obj
 
-  def process_response_keys(self, old_dict, listing_resource):
+  def process_response_keys(self, old_dict, listing_resource=None):
     """Converts keys in a response dictionary to resource proto format.
 
     Args:
         old_dict (dict): The dictionary to convert.
+        listing_resource (str): The resource type to convert to. Defaults to None.
 
     Returns:
         new_dict (dict): The dictionary with processed keys.
     """
-    old_dict[f'{listing_resource}_id'] = old_dict['id']
-    old_dict.pop('id')
+    if listing_resource:
+      old_dict[f'{listing_resource}_id'] = old_dict['id']
+      old_dict.pop('id')
 
     def convert_recursive(item):
       if isinstance(item, dict):
         new_item = {}
         for key, value in item.items():
+          if key == 'default_value':
+            # Map infer param value to proto value
+            value_map = dict(number_value=None, string_value=None, bool_value=None)
+
+            def map_fn(v):
+              return 'number_value' if isinstance(v, float) or isinstance(v, int) else \
+              'string_value' if isinstance(v, str) else \
+              'bool_value' if isinstance(v, bool) else None
+
+            value_map[map_fn(value)] = value
+            value = struct_pb2.Value(**value_map)
           if key in ['created_at', 'modified_at', 'completed_at']:
             value = self.convert_string_to_timestamp(value)
           elif key in ['workflow_recommended']:

--- a/clarifai/client/model.py
+++ b/clarifai/client/model.py
@@ -6,10 +6,12 @@ from clarifai_grpc.grpc.api import resources_pb2, service_pb2
 from clarifai_grpc.grpc.api.resources_pb2 import Input
 from clarifai_grpc.grpc.api.status import status_code_pb2
 from google.protobuf.json_format import MessageToDict
+from google.protobuf.struct_pb2 import Struct
 
 from clarifai.client.base import BaseClient
+from clarifai.client.input import Inputs
 from clarifai.client.lister import Lister
-from clarifai.errors import UserError
+from clarifai.errors import ApiClientError, UserError
 from clarifai.urls.helper import ClarifaiUrlHelper
 from clarifai.utils.logging import get_logger
 from clarifai.utils.misc import BackoffIterator
@@ -22,7 +24,6 @@ class Model(Lister, BaseClient):
                url_init: str = "",
                model_id: str = "",
                model_version: Dict = {'id': ""},
-               output_config: Dict = {'min_value': 0},
                base_url: str = "https://api.clarifai.com",
                **kwargs):
     """Initializes a Model object.
@@ -31,11 +32,6 @@ class Model(Lister, BaseClient):
         url_init (str): The URL to initialize the model object.
         model_id (str): The Model ID to interact with.
         model_version (dict): The Model Version to interact with.
-        output_config (dict): The output config to interact with.
-          min_value (float): The minimum value of the prediction confidence to filter.
-          max_concepts (int): The maximum number of concepts to return.
-          select_concepts (list[Concept]): The concepts to select.
-          sample_ms (int): The number of milliseconds to sample.
         base_url (str): Base API url. Default "https://api.clarifai.com"
         **kwargs: Additional keyword arguments to be passed to the Model.
     """
@@ -48,8 +44,7 @@ class Model(Lister, BaseClient):
           url_init)
       model_version = {'id': model_version_id}
       kwargs = {'user_id': user_id, 'app_id': app_id}
-    self.kwargs = {**kwargs, 'id': model_id, 'model_version': model_version,
-                   'output_info': {'output_config': output_config}}
+    self.kwargs = {**kwargs, 'id': model_id, 'model_version': model_version,}
     self.model_info = resources_pb2.Model(**self.kwargs)
     self.logger = get_logger(logger_level="INFO")
     BaseClient.__init__(self, user_id=self.user_id, app_id=self.app_id, base=base_url)
@@ -128,15 +123,18 @@ class Model(Lister, BaseClient):
       del model_version_info['model_version_id']
       yield Model(model_id=self.id, **dict(self.kwargs, model_version=model_version_info))
 
-  def predict(self, inputs: List[Input]):
+  def predict(self, inputs: List[Input], inference_params: Dict = {}, output_config: Dict = {}):
     """Predicts the model based on the given inputs.
 
     Args:
         inputs (list[Input]): The inputs to predict, must be less than 128.
     """
+    if not isinstance(inputs, list):
+      raise UserError('Invalid inputs, inputs must be a list of Input objects.')
     if len(inputs) > 128:
       raise UserError("Too many inputs. Max is 128.")  # TODO Use Chunker for inputs len > 128
 
+    self._override_model_version(inference_params, output_config)
     request = service_pb2.PostModelOutputsRequest(
         user_app_id=self.user_app_id,
         model_id=self.id,
@@ -163,98 +161,164 @@ class Model(Lister, BaseClient):
 
     return response
 
-  def predict_by_filepath(self, filepath: str, input_type: str):
+  def predict_by_filepath(self,
+                          filepath: str,
+                          inference_params: Dict = {},
+                          output_config: Dict = {}):
     """Predicts the model based on the given filepath.
 
     Args:
         filepath (str): The filepath to predict.
-        input_type (str): The type of input. Can be 'image', 'text', 'video' or 'audio.
+        inference_params (dict): The inference params to override.
+        output_config (dict): The output config to override.
+          min_value (float): The minimum value of the prediction confidence to filter.
+          max_concepts (int): The maximum number of concepts to return.
+          select_concepts (list[Concept]): The concepts to select.
 
     Example:
         >>> from clarifai.client.model import Model
         >>> model = Model("model_url") # Example URL: https://clarifai.com/clarifai/main/models/general-image-recognition
                     or
         >>> model = Model(model_id='model_id', user_id='user_id', app_id='app_id')
-        >>> model_prediction = model.predict_by_filepath('/path/to/image.jpg', 'image')
-        >>> model_prediction = model.predict_by_filepath('/path/to/text.txt', 'text')
+        >>> model_prediction = model.predict_by_filepath('/path/to/image.jpg')
+        >>> model_prediction = model.predict_by_filepath('/path/to/text.txt'])
     """
-    if input_type not in ['image', 'text', 'video', 'audio']:
-      raise UserError('Invalid input type it should be image, text, video or audio.')
     if not os.path.isfile(filepath):
       raise UserError('Invalid filepath.')
 
     with open(filepath, "rb") as f:
       file_bytes = f.read()
 
-    return self.predict_by_bytes(file_bytes, input_type)
+    return self.predict_by_bytes(file_bytes, inference_params, output_config)
 
-  def predict_by_bytes(self, input_bytes: bytes, input_type: str):
+  def predict_by_bytes(self,
+                       input_bytes: bytes,
+                       inference_params: Dict = {},
+                       output_config: Dict = {}):
     """Predicts the model based on the given bytes.
 
     Args:
         input_bytes (bytes): File Bytes to predict on.
-        input_type (str): The type of input. Can be 'image', 'text', 'video' or 'audio'.
+        inference_params (dict): The inference params to override.
+        output_config (dict): The output config to override.
+          min_value (float): The minimum value of the prediction confidence to filter.
+          max_concepts (int): The maximum number of concepts to return.
+          select_concepts (list[Concept]): The concepts to select.
 
     Example:
         >>> from clarifai.client.model import Model
-        >>> model = Model("https://clarifai.com/anthropic/completion/models/claude-v2")
-        >>> model_prediction = model.predict_by_bytes(b'Write a tweet on future of AI', 'text')
+        >>> model = Model("https://clarifai.com/openai/chat-completion/models/GPT-4")
+        >>> model_prediction = model.predict_by_bytes(b'Write a tweet on future of AI', inference_params=dict(temperature=str(0.7), max_tokens=30)))
     """
+    try:
+      input_type = next(iter(self.kwargs['model_version']['input_info']['fields_map']))
+    except KeyError:
+      self.load_info()
+      input_type = next(iter(self.kwargs['model_version']['input_info']['fields_map']))
+
+    if len(self.kwargs['model_version']['input_info']['fields_map']) > 1:
+      raise UserError('For MultiModal models, please use `predict` method.')
     if input_type not in {'image', 'text', 'video', 'audio'}:
-      raise UserError('Invalid input type it should be image, text, video or audio.')
+      raise ApiClientError(
+          f"Got input type {self.input_type} but expected one of image, text, video, audio.")
     if not isinstance(input_bytes, bytes):
       raise UserError('Invalid bytes.')
-    # TODO will obtain proto from input class
+
     if input_type == "image":
-      input_proto = resources_pb2.Input(
-          data=resources_pb2.Data(image=resources_pb2.Image(base64=input_bytes)))
+      input_proto = Inputs().get_input_from_bytes("", image_bytes=input_bytes)
     elif input_type == "text":
-      input_proto = resources_pb2.Input(
-          data=resources_pb2.Data(text=resources_pb2.Text(raw=input_bytes)))
+      input_proto = Inputs().get_input_from_bytes("", text_bytes=input_bytes)
     elif input_type == "video":
-      input_proto = resources_pb2.Input(
-          data=resources_pb2.Data(video=resources_pb2.Video(base64=input_bytes)))
+      input_proto = Inputs().get_input_from_bytes("", video_bytes=input_bytes)
     elif input_type == "audio":
-      input_proto = resources_pb2.Input(
-          data=resources_pb2.Data(audio=resources_pb2.Audio(base64=input_bytes)))
+      input_proto = Inputs().get_input_from_bytes("", audio_bytes=input_bytes)
 
-    return self.predict(inputs=[input_proto])
+    return self.predict(
+        inputs=[input_proto], inference_params=inference_params, output_config=output_config)
 
-  def predict_by_url(self, url: str, input_type: str):
+  def predict_by_url(self, url: str, inference_params: Dict = {}, output_config: Dict = {}):
     """Predicts the model based on the given URL.
 
     Args:
         url (str): The URL to predict.
-        input_type (str): The type of input. Can be 'image', 'text', 'video' or 'audio.
+        inference_params (dict): The inference params to override.
+        output_config (dict): The output config to override.
+          min_value (float): The minimum value of the prediction confidence to filter.
+          max_concepts (int): The maximum number of concepts to return.
+          select_concepts (list[Concept]): The concepts to select.
 
     Example:
         >>> from clarifai.client.model import Model
         >>> model = Model("model_url") # Example URL: https://clarifai.com/clarifai/main/models/general-image-recognition
                     or
         >>> model = Model(model_id='model_id', user_id='user_id', app_id='app_id')
-        >>> model_prediction = model.predict_by_url('url', 'image')
+        >>> model_prediction = model.predict_by_url('url')
     """
-    if input_type not in {'image', 'text', 'video', 'audio'}:
-      raise UserError('Invalid input type it should be image, text, video or audio.')
-    # TODO will be obtain proto from input class
-    if input_type == "image":
-      input_proto = resources_pb2.Input(
-          data=resources_pb2.Data(image=resources_pb2.Image(url=url)))
-    elif input_type == "text":
-      input_proto = resources_pb2.Input(data=resources_pb2.Data(text=resources_pb2.Text(url=url)))
-    elif input_type == "video":
-      input_proto = resources_pb2.Input(
-          data=resources_pb2.Data(video=resources_pb2.Video(url=url)))
-    elif input_type == "audio":
-      input_proto = resources_pb2.Input(
-          data=resources_pb2.Data(audio=resources_pb2.Audio(url=url)))
+    try:
+      input_type = next(iter(self.kwargs['model_version']['input_info']['fields_map']))
+    except KeyError:
+      self.load_info()
+      input_type = next(iter(self.kwargs['model_version']['input_info']['fields_map']))
 
-    return self.predict(inputs=[input_proto])
+    if len(self.kwargs['model_version']['input_info']['fields_map']) > 1:
+      raise UserError('For MultiModal models, please use `predict` method.')
+    if input_type not in {'image', 'text', 'video', 'audio'}:
+      raise ApiClientError(
+          f"Got input type {self.input_type} but expected one of image, text, video, audio.")
+
+    if input_type == "image":
+      input_proto = Inputs().get_input_from_url("", image_url=url)
+    elif input_type == "text":
+      input_proto = Inputs().get_input_from_url("", text_url=url)
+    elif input_type == "video":
+      input_proto = Inputs().get_input_from_url("", video_url=url)
+    elif input_type == "audio":
+      input_proto = Inputs().get_input_from_url("", audio_url=url)
+
+    return self.predict(
+        inputs=[input_proto], inference_params=inference_params, output_config=output_config)
+
+  def _override_model_version(self, inference_params: Dict = {}, output_config: Dict = {}) -> None:
+    """Overrides the model version.
+
+    Args:
+        inference_params (dict): The inference params to override.
+        output_config (dict): The output config to override.
+          min_value (float): The minimum value of the prediction confidence to filter.
+          max_concepts (int): The maximum number of concepts to return.
+          select_concepts (list[Concept]): The concepts to select.
+          sample_ms (int): The number of milliseconds to sample.
+    """
+    if inference_params is not None:
+      params = Struct()
+      params.update(inference_params)
+
+    self.model_info.model_version.output_info.CopyFrom(
+        resources_pb2.OutputInfo(
+            output_config=resources_pb2.OutputConfig(**output_config), params=params))
+
+  def load_info(self) -> None:
+    """Loads the model info."""
+    request = service_pb2.GetModelRequest(
+        user_app_id=self.user_app_id,
+        model_id=self.id,
+        version_id=self.model_info.model_version.id)
+    response = self._grpc_request(self.STUB.GetModel, request)
+
+    if response.status.code != status_code_pb2.SUCCESS:
+      raise Exception(response.status)
+
+    dict_response = MessageToDict(response, preserving_proto_field_name=True)
+    self.kwargs = self.process_response_keys(dict_response['model'])
+    self.model_info = resources_pb2.Model(**self.kwargs)
 
   def __getattr__(self, name):
     return getattr(self.model_info, name)
 
   def __str__(self):
+    if len(self.kwargs) < 10:
+      self.load_info()
+
     init_params = [param for param in self.kwargs.keys()]
     attribute_strings = [
         f"{param}={getattr(self.model_info, param)}" for param in init_params

--- a/clarifai/client/model.py
+++ b/clarifai/client/model.py
@@ -147,8 +147,7 @@ class Model(Lister, BaseClient):
     while True:
       response = self._grpc_request(self.STUB.PostModelOutputs, request)
 
-      if response.outputs and \
-        response.outputs[0].status.code == status_code_pb2.MODEL_DEPLOYING and \
+      if response.status.code == status_code_pb2.MODEL_DEPLOYING and \
         time.time() - start_time < 60 * 10: # 10 minutes
         self.logger.info(f"{self.id} model is still deploying, please wait...")
         time.sleep(next(backoff_iterator))

--- a/clarifai/client/workflow.py
+++ b/clarifai/client/workflow.py
@@ -6,6 +6,7 @@ from clarifai_grpc.grpc.api.resources_pb2 import Input
 from clarifai_grpc.grpc.api.status import status_code_pb2
 
 from clarifai.client.base import BaseClient
+from clarifai.client.input import Inputs
 from clarifai.client.lister import Lister
 from clarifai.errors import UserError
 from clarifai.urls.helper import ClarifaiUrlHelper
@@ -111,17 +112,13 @@ class Workflow(Lister, BaseClient):
       raise UserError('Invalid bytes.')
 
     if input_type == "image":
-      input_proto = resources_pb2.Input(
-          data=resources_pb2.Data(image=resources_pb2.Image(base64=input_bytes)))
+      input_proto = Inputs().get_input_from_bytes("", image_bytes=input_bytes)
     elif input_type == "text":
-      input_proto = resources_pb2.Input(
-          data=resources_pb2.Data(text=resources_pb2.Text(raw=input_bytes)))
+      input_proto = Inputs().get_input_from_bytes("", text_bytes=input_bytes)
     elif input_type == "video":
-      input_proto = resources_pb2.Input(
-          data=resources_pb2.Data(video=resources_pb2.Video(base64=input_bytes)))
+      input_proto = Inputs().get_input_from_bytes("", video_bytes=input_bytes)
     elif input_type == "audio":
-      input_proto = resources_pb2.Input(
-          data=resources_pb2.Data(audio=resources_pb2.Audio(base64=input_bytes)))
+      input_proto = Inputs().get_input_from_bytes("", audio_bytes=input_bytes)
 
     return self.predict(inputs=[input_proto])
 
@@ -143,16 +140,13 @@ class Workflow(Lister, BaseClient):
       raise UserError('Invalid input type it should be image, text, video or audio.')
 
     if input_type == "image":
-      input_proto = resources_pb2.Input(
-          data=resources_pb2.Data(image=resources_pb2.Image(url=url)))
+      input_proto = Inputs().get_input_from_url("", image_url=url)
     elif input_type == "text":
-      input_proto = resources_pb2.Input(data=resources_pb2.Data(text=resources_pb2.Text(url=url)))
+      input_proto = Inputs().get_input_from_url("", text_url=url)
     elif input_type == "video":
-      input_proto = resources_pb2.Input(
-          data=resources_pb2.Data(video=resources_pb2.Video(url=url)))
+      input_proto = Inputs().get_input_from_url("", video_url=url)
     elif input_type == "audio":
-      input_proto = resources_pb2.Input(
-          data=resources_pb2.Data(audio=resources_pb2.Audio(url=url)))
+      input_proto = Inputs().get_input_from_url("", audio_url=url)
 
     return self.predict(inputs=[input_proto])
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import datetime
 
 import pytest
 
@@ -7,17 +8,18 @@ from clarifai.client.app import App
 from clarifai.client.user import User
 from clarifai.constants.search import DEFAULT_TOP_K
 
+NOW = str(int(datetime.now().timestamp()))
 MAIN_APP_ID = "main"
 MAIN_APP_USER_ID = "clarifai"
 GENERAL_MODEL_ID = "general-image-recognition"
 General_Workflow_ID = "General"
 
 CREATE_APP_USER_ID = os.environ["CLARIFAI_USER_ID"]
-CREATE_APP_ID = "ci_test_app"
-CREATE_MODEL_ID = "ci_test_model"
-CREATE_DATASET_ID = "ci_test_dataset"
-CREATE_MODULE_ID = "ci_test_module"
-CREATE_RUNNER_ID = "ci_test_runner"
+CREATE_APP_ID = f"ci_test_app_{NOW}"
+CREATE_MODEL_ID = f"ci_test_model_{NOW}"
+CREATE_DATASET_ID = f"ci_test_dataset_{NOW}"
+CREATE_MODULE_ID = f"ci_test_module_{NOW}"
+CREATE_RUNNER_ID = f"ci_test_runner_{NOW}"
 
 
 @pytest.fixture

--- a/tests/test_model_predict.py
+++ b/tests/test_model_predict.py
@@ -3,6 +3,7 @@ import os
 import pytest
 from clarifai_grpc.grpc.api import resources_pb2
 
+from clarifai.client.input import Inputs
 from clarifai.client.model import Model
 from clarifai.errors import UserError
 
@@ -30,12 +31,12 @@ def validate_concepts_length(response):
 
 
 def test_predict_image_url(model):
-  response = model.predict_by_url(DOG_IMAGE_URL, input_type="image")
+  response = model.predict_by_url(DOG_IMAGE_URL)
   validate_concepts_length(response)
 
 
 def test_predict_filepath(model):
-  response = model.predict_by_filepath(RED_TRUCK_IMAGE_FILE_PATH, input_type="image")
+  response = model.predict_by_filepath(RED_TRUCK_IMAGE_FILE_PATH)
   validate_concepts_length(response)
 
 
@@ -43,7 +44,7 @@ def test_predict_image_bytes(model):
   with open(RED_TRUCK_IMAGE_FILE_PATH, "rb") as f:
     image_bytes = f.read()
 
-  response = model.predict_by_bytes(image_bytes, input_type="image")
+  response = model.predict_by_bytes(image_bytes)
   validate_concepts_length(response)
 
 
@@ -53,14 +54,10 @@ def test_predict_image_url_with_selected_concepts():
       resources_pb2.Concept(name="cat"),
   ]
   model_with_selected_concepts = Model(
-      user_id=MAIN_APP_USER_ID,
-      app_id=MAIN_APP_ID,
-      model_id=GENERAL_MODEL_ID,
-      output_config={
-          "select_concepts": selected_concepts
-      })
+      user_id=MAIN_APP_USER_ID, app_id=MAIN_APP_ID, model_id=GENERAL_MODEL_ID)
 
-  response = model_with_selected_concepts.predict_by_url(DOG_IMAGE_URL, input_type="image")
+  response = model_with_selected_concepts.predict_by_url(
+      DOG_IMAGE_URL, output_config=dict(select_concepts=selected_concepts))
   concepts = response.outputs[0].data.concepts
 
   assert len(concepts) == 2
@@ -74,11 +71,9 @@ def test_predict_image_url_with_min_value():
       user_id=MAIN_APP_USER_ID,
       app_id=MAIN_APP_ID,
       model_id=GENERAL_MODEL_ID,
-      output_config={
-          "min_value": 0.98
-      })
+  )
 
-  response = model_with_min_value.predict_by_url(DOG_IMAGE_URL, input_type="image")
+  response = model_with_min_value.predict_by_url(DOG_IMAGE_URL, output_config=dict(min_value=0.98))
   assert len(response.outputs[0].data.concepts) > 0
   for c in response.outputs[0].data.concepts:
     assert c.value >= 0.98
@@ -86,14 +81,10 @@ def test_predict_image_url_with_min_value():
 
 def test_predict_image_url_with_max_concepts():
   model_with_max_concepts = Model(
-      user_id=MAIN_APP_USER_ID,
-      app_id=MAIN_APP_ID,
-      model_id=GENERAL_MODEL_ID,
-      output_config={
-          "max_concepts": 3
-      })
+      user_id=MAIN_APP_USER_ID, app_id=MAIN_APP_ID, model_id=GENERAL_MODEL_ID)
 
-  response = model_with_max_concepts.predict_by_url(DOG_IMAGE_URL, input_type="image")
+  response = model_with_max_concepts.predict_by_url(
+      DOG_IMAGE_URL, output_config=dict(max_concepts=3))
   assert len(response.outputs[0].data.concepts) == 3
 
 
@@ -101,11 +92,11 @@ def test_failed_predicts(model):
   # Invalid FilePath
   false_filepath = "false_filepath"
   with pytest.raises(UserError):
-    model.predict_by_filepath(false_filepath, input_type="image")
+    model.predict_by_filepath(false_filepath)
 
   # Invalid URL
   with pytest.raises(Exception):
-    model.predict_by_url(NON_EXISTING_IMAGE_URL, input_type="image")
+    model.predict_by_url(NON_EXISTING_IMAGE_URL)
 
 
 def test_predict_video_url_with_custom_sample_ms():
@@ -113,11 +104,9 @@ def test_predict_video_url_with_custom_sample_ms():
       user_id=MAIN_APP_USER_ID,
       app_id=MAIN_APP_ID,
       model_id=GENERAL_MODEL_ID,
-      output_config={
-          "sample_ms": 2000
-      })
-
-  response = model_with_custom_sample_ms.predict_by_url(BEER_VIDEO_URL, input_type="video")
+  )
+  video_proto = Inputs().get_input_from_url("", video_url=BEER_VIDEO_URL)
+  response = model_with_custom_sample_ms.predict([video_proto], output_config=dict(sample_ms=2000))
   # The expected time per frame is the middle between the start and the end of the frame
   # (in milliseconds).
   expected_time = 1000
@@ -133,8 +122,10 @@ def test_text_embed_predict_with_raw_text():
   clip_embed_model = Model(
       user_id=MAIN_APP_USER_ID, app_id=MAIN_APP_ID, model_id=CLIP_EMBED_MODEL_ID)
 
-  response = clip_embed_model.predict_by_bytes(RAW_TEXT.encode(encoding='UTF-8'), "text")
+  input_text_proto = Inputs().get_input_from_bytes(
+      "", text_bytes=RAW_TEXT.encode(encoding='UTF-8'))
+  response = clip_embed_model.predict([input_text_proto])
   assert response.outputs[0].data.embeddings[0].num_dimensions == clip_dim
 
-  response = clip_embed_model.predict_by_bytes(RAW_TEXT_BYTES, "text")
+  response = clip_embed_model.predict([input_text_proto])
   assert response.outputs[0].data.embeddings[0].num_dimensions == clip_dim

--- a/tests/test_model_predict.py
+++ b/tests/test_model_predict.py
@@ -31,12 +31,12 @@ def validate_concepts_length(response):
 
 
 def test_predict_image_url(model):
-  response = model.predict_by_url(DOG_IMAGE_URL)
+  response = model.predict_by_url(DOG_IMAGE_URL, 'image')
   validate_concepts_length(response)
 
 
 def test_predict_filepath(model):
-  response = model.predict_by_filepath(RED_TRUCK_IMAGE_FILE_PATH)
+  response = model.predict_by_filepath(RED_TRUCK_IMAGE_FILE_PATH, 'image')
   validate_concepts_length(response)
 
 
@@ -44,7 +44,7 @@ def test_predict_image_bytes(model):
   with open(RED_TRUCK_IMAGE_FILE_PATH, "rb") as f:
     image_bytes = f.read()
 
-  response = model.predict_by_bytes(image_bytes)
+  response = model.predict_by_bytes(image_bytes, 'image')
   validate_concepts_length(response)
 
 
@@ -57,7 +57,7 @@ def test_predict_image_url_with_selected_concepts():
       user_id=MAIN_APP_USER_ID, app_id=MAIN_APP_ID, model_id=GENERAL_MODEL_ID)
 
   response = model_with_selected_concepts.predict_by_url(
-      DOG_IMAGE_URL, output_config=dict(select_concepts=selected_concepts))
+      DOG_IMAGE_URL, 'image', output_config=dict(select_concepts=selected_concepts))
   concepts = response.outputs[0].data.concepts
 
   assert len(concepts) == 2
@@ -73,7 +73,8 @@ def test_predict_image_url_with_min_value():
       model_id=GENERAL_MODEL_ID,
   )
 
-  response = model_with_min_value.predict_by_url(DOG_IMAGE_URL, output_config=dict(min_value=0.98))
+  response = model_with_min_value.predict_by_url(
+      DOG_IMAGE_URL, 'image', output_config=dict(min_value=0.98))
   assert len(response.outputs[0].data.concepts) > 0
   for c in response.outputs[0].data.concepts:
     assert c.value >= 0.98
@@ -84,7 +85,7 @@ def test_predict_image_url_with_max_concepts():
       user_id=MAIN_APP_USER_ID, app_id=MAIN_APP_ID, model_id=GENERAL_MODEL_ID)
 
   response = model_with_max_concepts.predict_by_url(
-      DOG_IMAGE_URL, output_config=dict(max_concepts=3))
+      DOG_IMAGE_URL, 'image', output_config=dict(max_concepts=3))
   assert len(response.outputs[0].data.concepts) == 3
 
 
@@ -92,11 +93,15 @@ def test_failed_predicts(model):
   # Invalid FilePath
   false_filepath = "false_filepath"
   with pytest.raises(UserError):
-    model.predict_by_filepath(false_filepath)
+    model.predict_by_filepath(false_filepath, 'image')
 
   # Invalid URL
   with pytest.raises(Exception):
-    model.predict_by_url(NON_EXISTING_IMAGE_URL)
+    model.predict_by_url(NON_EXISTING_IMAGE_URL, 'image')
+
+  # Invalid Input Type
+  with pytest.raises(UserError):
+    model.predict_by_url(DOG_IMAGE_URL, 'invalid_input_type')
 
 
 def test_predict_video_url_with_custom_sample_ms():

--- a/tests/test_model_predict.py
+++ b/tests/test_model_predict.py
@@ -134,3 +134,11 @@ def test_text_embed_predict_with_raw_text():
 
   response = clip_embed_model.predict([input_text_proto])
   assert response.outputs[0].data.embeddings[0].num_dimensions == clip_dim
+
+
+def test_model_load_info():
+  clip_embed_model = Model(
+      user_id=MAIN_APP_USER_ID, app_id=MAIN_APP_ID, model_id=CLIP_EMBED_MODEL_ID)
+  assert len(clip_embed_model.kwargs) == 4
+  clip_embed_model.load_info()
+  assert len(clip_embed_model.kwargs) > 10

--- a/tests/workflow/test_create_delete.py
+++ b/tests/workflow/test_create_delete.py
@@ -2,13 +2,15 @@ import glob
 import logging
 import os
 import typing
+from datetime import datetime
 
 import pytest
 
 from clarifai.client.user import User
 
+NOW = str(int(datetime.now().timestamp()))
 CREATE_APP_USER_ID = os.environ["CLARIFAI_USER_ID"]
-CREATE_APP_ID = "test_workflow_create_delete_app"
+CREATE_APP_ID = f"test_workflow_create_delete_app_{NOW}"
 
 
 def get_test_parse_workflow_creation_workflows() -> typing.List[str]:


### PR DESCRIPTION
#### Model Predict
```python
# Note: CLARIFAI_PAT must be set as env variable.
from clarifai.client.model import Model

"""
Get Model information on details of model(description, usecases..etc) and info on training or
# other inference parameters(eg: temperature, top_k, max_tokens..etc for LLMs)
"""
gpt_4_model = Model("https://clarifai.com/openai/chat-completion/models/GPT-4")
print(gpt_4_model)


# Customizing Model Inference Output
model_prediction = gpt_4_model.predict_by_bytes(b"Write a tweet on future of AI", "text", inference_params=dict(temperature=str(0.7), max_tokens=30))
# Return predictions having prediction confidence > 0.98
model_prediction = model.predict_by_filepath(filepath="local_filepath", input_type, output_config={"min_value": 0.98}) # Supports image, text, audio, video

# Return predictions for specified interval of video
video_input_proto = [input_obj.get_input_from_url("Input_id", video_url=BEER_VIDEO_URL)]
model_prediction = model.predict(video_input_proto, input_type="video", output_config={"sample_ms": 2000})
```