### PR TITLE
change pycocotools to extras require

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,11 @@
 clarifai-grpc==9.10.0
-pandas==1.3.5
-numpy==1.22.0
+pandas>=1.3.5
+numpy>=1.22.0
 tqdm>=4.65.0
 omegaconf==2.2.3
-pycocotools==2.0.6
 opencv-python==4.7.0.68
 tritonclient==2.34.0
-rich==13.4.2
+rich>=13.4.2
 pytest==7.4.1
-PyYAML==6.0.1
+PyYAML>=6.0.1
 schema==0.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ rich>=13.4.2
 pytest==7.4.1
 PyYAML>=6.0.1
 schema==0.7.5
+Pillow>=9.5.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
     python_requires='>=3.8',
     install_requires=install_requires,
     extras_require={
-        'data': ["pycocotools=2.0.6"],
+        'all': ["pycocotools=2.0.6"],
     },
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ setuptools.setup(
     license="Apache 2.0",
     python_requires='>=3.8',
     install_requires=install_requires,
+    extras_require={
+        'data': ["pycocotools=2.0.6"],
+    },
     entry_points={
         "console_scripts": [
             "clarifai-model-upload-init = clarifai.models.model_serving.cli.repository:model_upload_init",


### PR DESCRIPTION
Relax pandas, numpy, pyyaml, pillow, rich versions 
change pycocotools to extras_require (`pip install "clarifai[all]"`)