### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+global-include *.css
+include clarifai/modules/style.css
+recursive-include clarifai *


### PR DESCRIPTION
## Why
 - Adding MANIFEST back so that `.css` files are included in Pypi build