### PR TITLE
Remove pytest requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ omegaconf==2.2.3
 opencv-python==4.7.0.68
 tritonclient==2.34.0
 rich>=13.4.2
-pytest==7.4.1
 PyYAML>=6.0.1
 schema==0.7.5
 Pillow>=9.5.0


### PR DESCRIPTION
As far as I can tell, pytest is not a necessary requirement for the library itself.

It's already included in tests/requirements.txt, and in fact, is overridden (from ==7.4.1 in requirements.txt to ==7.1.2 in tests/requirements.txt) in the `Run tests` GitHub Actions workflow (e.g. https://github.com/Clarifai/clarifai-python/actions/runs/6970572930/job/18968766681#step:4:179).