### PR TITLE
Ensure support for Python 3.10-3.12

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
   publish-pypi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -33,7 +33,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -16,18 +16,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9]
-        exclude:
-          - os: macos-latest
-            python-version: 3.9
-        include:
-          - os: windows-latest
-            python-version: 3.8.10
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version:
+          - '3.12'
+          - '3.11'
+          - '3.10'
+          - '3.9'
+          - '3.8'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,13 @@ setuptools.setup(
     classifiers=[
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: Implementation :: CPython",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
Hello,

I believe it would be nice to make sure that modern Python versions are supported by the Clarifai Python SDK, so I'd like to suggest changes that:
  * enable testing for Python 3.10-3.12 on CI
  * add corresponding [classifiers](https://pypi.org/classifiers/) to `setup.py`
  * bump `actions/checkout` to [v4](https://github.com/actions/checkout/releases/tag/v4)
  * bump `actions/setup-python` to [v4](https://github.com/actions/setup-python/releases/tag/v4)

Best regards!