### PR TITLE
Remove OmegaConf requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ clarifai-grpc==9.10.0
 pandas>=1.3.5
 numpy>=1.22.0
 tqdm>=4.65.0
-omegaconf==2.2.3
 opencv-python==4.7.0.68
 tritonclient==2.34.0
 rich>=13.4.2


### PR DESCRIPTION
As far as I can tell, OmegaConf is not used at all anymore in the library.

It seems to have been added as a requirement for a singular usage in `clarifai_utils/data_upload/upload.py` in https://github.com/Clarifai/clarifai-python/commit/c3cf0d6dec57247a800bad1430bb1b4979c722c1.
That usage was later removed in https://github.com/Clarifai/clarifai-python/commit/0685e60c7eaf1d2bb7714518de49ad3d886dddd4, and the file itself was removed entirely in https://github.com/Clarifai/clarifai-python/commit/0f292bc098bf7ae590fab6c68304b978547fe4ff.