### PR TITLE
Support multimodal inputs for inference

### DIFF
--- a/clarifai/client/input.py
+++ b/clarifai/client/input.py
@@ -283,15 +283,17 @@ class Inputs(Lister, BaseClient):
   @staticmethod
   def get_multimodal_input(input_id: str,
                            raw_text: str,
+                           text_bytes: bytes = None,
                            image_url: str = None,
                            image_bytes: bytes = None,
                            dataset_id: str = None,
                            **kwargs) -> Text:
-    """Create input proto for text data type from raw text and image from bytes or url.
+    """Create input proto for text and image from bytes or url.
 
     Args:
         input_id (str): The input ID for the input to create.
         raw_text (str): The raw text input.
+        text_bytes (str): The bytes for the text.
         image_url (str): The url for the image.
         image_bytes (str): The bytes for the image.
         dataset_id (str): The dataset ID for the dataset to add the input to.
@@ -304,8 +306,10 @@ class Inputs(Lister, BaseClient):
         >>> from clarifai.client.input import Inputs
         >>> input_protos = Inputs.get_multimodal_input(input_id = 'demo', raw_text = 'What time of day is it?', image_url='https://samples.clarifai.com/metro-north.jpg')
     """
-    image_pb = resources_pb2.Image(base64=image_bytes) if image_bytes and not image_url else None
-    image_pb = resources_pb2.Image(url=image_url) if image_url and not image_bytes else None
+    # Will only use URL if both bytes and URL are supplied.
+    image_pb = resources_pb2.Image(base64=image_bytes) if image_bytes else None
+    image_pb = resources_pb2.Image(url=image_url) if image_url else None
+    text_pb = resources_pb2.Text(raw=text_bytes) if text_bytes else None
     text_pb = resources_pb2.Text(raw=raw_text)
     return Inputs._get_proto(
         input_id=input_id, dataset_id=dataset_id, imagepb=image_pb, text_pb=text_pb, **kwargs)

--- a/clarifai/client/input.py
+++ b/clarifai/client/input.py
@@ -306,7 +306,11 @@ class Inputs(Lister, BaseClient):
         >>> from clarifai.client.input import Inputs
         >>> input_protos = Inputs.get_multimodal_input(input_id = 'demo', raw_text = 'What time of day is it?', image_url='https://samples.clarifai.com/metro-north.jpg')
     """
-    # Will only use URL if both bytes and URL are supplied.
+    if image_bytes and image_url:
+      return UserError("Please supply only one of image_bytes or image_url, and not both.")
+    if text_bytes and raw_text:
+      return UserError("Please supply only one of text_bytes or raw_text, and not both.")
+
     image_pb = resources_pb2.Image(base64=image_bytes) if image_bytes else None
     image_pb = resources_pb2.Image(url=image_url) if image_url else None
     text_pb = resources_pb2.Text(raw=text_bytes) if text_bytes else None

--- a/clarifai/client/input.py
+++ b/clarifai/client/input.py
@@ -304,8 +304,11 @@ class Inputs(Lister, BaseClient):
         >>> from clarifai.client.input import Inputs
         >>> input_protos = Inputs.get_multimodal_input(input_id = 'demo', raw_text = 'What time of day is it?', image_url='https://samples.clarifai.com/metro-north.jpg')
     """
+    image_pb = resources_pb2.Image(base64=image_bytes) if image_bytes and not image_url else None
+    image_pb = resources_pb2.Image(url=image_url) if image_url and not image_bytes else None
     text_pb = resources_pb2.Text(raw=raw_text)
-    return Inputs._get_proto(input_id=input_id, dataset_id=dataset_id, text_pb=text_pb, **kwargs)
+    return Inputs._get_proto(
+        input_id=input_id, dataset_id=dataset_id, imagepb=image_pb, text_pb=text_pb, **kwargs)
 
   @staticmethod
   def get_inputs_from_csv(csv_path: str,

--- a/clarifai/client/input.py
+++ b/clarifai/client/input.py
@@ -262,7 +262,7 @@ class Inputs(Lister, BaseClient):
   @staticmethod
   def get_text_input(input_id: str, raw_text: str, dataset_id: str = None,
                      **kwargs) -> Text:  #text specific
-    """Create input proto for text data type from rawtext.
+    """Create input proto for text data type from raw text.
 
     Args:
         input_id (str): The input ID for the input to create.
@@ -287,7 +287,7 @@ class Inputs(Lister, BaseClient):
                            image_bytes: bytes = None,
                            dataset_id: str = None,
                            **kwargs) -> Text:
-    """Create input proto for text data type from rawtext.
+    """Create input proto for text data type from raw text and image from bytes or url.
 
     Args:
         input_id (str): The input ID for the input to create.

--- a/clarifai/client/input.py
+++ b/clarifai/client/input.py
@@ -282,7 +282,7 @@ class Inputs(Lister, BaseClient):
 
   @staticmethod
   def get_multimodal_input(input_id: str,
-                           raw_text: str,
+                           raw_text: str = None,
                            text_bytes: bytes = None,
                            image_url: str = None,
                            image_bytes: bytes = None,
@@ -306,9 +306,9 @@ class Inputs(Lister, BaseClient):
         >>> from clarifai.client.input import Inputs
         >>> input_protos = Inputs.get_multimodal_input(input_id = 'demo', raw_text = 'What time of day is it?', image_url='https://samples.clarifai.com/metro-north.jpg')
     """
-    if image_bytes and image_url:
+    if (image_bytes and image_url) or (not image_url and not image_url):
       return UserError("Please supply only one of image_bytes or image_url, and not both.")
-    if text_bytes and raw_text:
+    if (text_bytes and raw_text) or (not text_bytes and not raw_text):
       return UserError("Please supply only one of text_bytes or raw_text, and not both.")
 
     image_pb = resources_pb2.Image(base64=image_bytes) if image_bytes else None

--- a/clarifai/client/input.py
+++ b/clarifai/client/input.py
@@ -281,6 +281,33 @@ class Inputs(Lister, BaseClient):
     return Inputs._get_proto(input_id=input_id, dataset_id=dataset_id, text_pb=text_pb, **kwargs)
 
   @staticmethod
+  def get_multimodal_input(input_id: str,
+                           raw_text: str,
+                           image_url: str = None,
+                           image_bytes: bytes = None,
+                           dataset_id: str = None,
+                           **kwargs) -> Text:
+    """Create input proto for text data type from rawtext.
+
+    Args:
+        input_id (str): The input ID for the input to create.
+        raw_text (str): The raw text input.
+        image_url (str): The url for the image.
+        image_bytes (str): The bytes for the image.
+        dataset_id (str): The dataset ID for the dataset to add the input to.
+        **kwargs: Additional keyword arguments to be passed to the Input
+
+    Returns:
+        Input: An Input object for the specified input ID.
+
+    Example:
+        >>> from clarifai.client.input import Inputs
+        >>> input_protos = Inputs.get_multimodal_input(input_id = 'demo', raw_text = 'What time of day is it?', image_url='https://samples.clarifai.com/metro-north.jpg')
+    """
+    text_pb = resources_pb2.Text(raw=raw_text)
+    return Inputs._get_proto(input_id=input_id, dataset_id=dataset_id, text_pb=text_pb, **kwargs)
+
+  @staticmethod
   def get_inputs_from_csv(csv_path: str,
                           input_type: str = 'text',
                           csv_type: str = 'raw',

--- a/clarifai/client/input.py
+++ b/clarifai/client/input.py
@@ -311,10 +311,10 @@ class Inputs(Lister, BaseClient):
     if (text_bytes and raw_text) or (not text_bytes and not raw_text):
       return UserError("Please supply only one of text_bytes or raw_text, and not both.")
 
-    image_pb = resources_pb2.Image(base64=image_bytes) if image_bytes else None
-    image_pb = resources_pb2.Image(url=image_url) if image_url else None
-    text_pb = resources_pb2.Text(raw=text_bytes) if text_bytes else None
-    text_pb = resources_pb2.Text(raw=raw_text)
+    image_pb = resources_pb2.Image(base64=image_bytes) if image_bytes else resources_pb2.Image(
+        url=image_url) if image_url else None
+    text_pb = resources_pb2.Text(raw=text_bytes) if text_bytes else resources_pb2.Text(
+        raw=raw_text) if raw_text else None
     return Inputs._get_proto(
         input_id=input_id, dataset_id=dataset_id, imagepb=image_pb, text_pb=text_pb, **kwargs)
 


### PR DESCRIPTION
Support multimodal inputs for inference without using private methods

```diff
from clarifai.client.model import Model
from clarifai.client.input import Inputs

prompt = "What time of day is it?"
image_url = "https://samples.clarifai.com/metro-north.jpg"
inference_params = dict(temperature=0.2, max_tokens=100)

-text_pb = Inputs.get_input_from_bytes("", text_bytes=prompt.encode()).data.text
-image_pb = Inputs.get_input_from_url("", image_url= image_url).data.image

# Model Predict
model_prediction = Model("https://clarifai.com/openai/chat-completion/models/openai-gpt-4-vision").
-    predict(inputs = [Inputs._get_proto(input_id="",imagepb=image_pb,text_pb=text_pb)],
+    predict(inputs = [Inputs.get_multimodal_input(input_id="",image_url=image_url, raw_text=prompt)],
inference_params=inference_params)

print(model_prediction.outputs[0].data.text.raw)
```