### PR TITLE
[DEVX-322] Add Rank to PostInputsSearch

### DIFF
--- a/clarifai/schema/search.py
+++ b/clarifai/schema/search.py
@@ -20,6 +20,9 @@ def get_schema() -> Schema:
             - 'id': Non-empty string
             - 'language': Non-empty string
             - 'value': 0 or 1 integer
+        - 'input_types': List of 'image', 'video', 'text' or 'audio'
+        - 'input_dataset_ids': List of strings
+        - 'input_status_code': Integer
 
         Returns:
             Schema: The schema for rank and filter.

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -143,6 +143,18 @@ class TestAnnotationSearch:
       assert len(q.hits) == 1
       assert q.hits[0].input.id == "dog-tiff"
 
+  def test_rank_filter_search(self):
+    query = self.search.query(
+        ranks=[{
+            "image_url": "https://samples.clarifai.com/dog.tiff"
+        }],
+        filters=[{
+            "input_types": ["image"]
+        }])
+    for q in query:
+      assert len(q.hits) == 1
+      assert q.hits[0].input.id == "dog-tiff"
+
   def test_schema_error(self):
     with pytest.raises(UserError):
       _ = self.search.query(filters=[{


### PR DESCRIPTION
## Why
 - To support Rank based search in PostInputsSearch

## Tests
 - Added `test_rank_filter_search` test case

## How
```python
from clarifai.client.search import Search
search = Search(user_id="sai_nivedh", app_id="test-imdb", top_k=3, metric="cosine")

# InputSearch by raw text
results = search.query(ranks=[{"text_raw": "Movie is Awesome"}], filters=[{"input_types": ["text"]}])

for data in results:
  for hit in data.hits:
    print(hit.input.id)
```