### PR TITLE
Use specific URL method for apps

### DIFF
--- a/clarifai/client/app.py
+++ b/clarifai/client/app.py
@@ -47,7 +47,7 @@ class App(Lister, BaseClient):
     if url and app_id:
       raise UserError("You can only specify one of url or app_id.")
     if url:
-      user_id, app_id, _, _, _ = ClarifaiUrlHelper.split_clarifai_url(url)
+      user_id, app_id = ClarifaiUrlHelper.split_clarifai_app_url(url)
       kwargs = {'user_id': user_id}
     self.kwargs = {**kwargs, 'id': app_id}
     self.app_info = resources_pb2.App(**self.kwargs)

--- a/clarifai/urls/helper.py
+++ b/clarifai/urls/helper.py
@@ -59,6 +59,23 @@ class ClarifaiUrlHelper(object):
                                            resource_id, version_id)
 
   @classmethod
+  def split_clarifai_app_url(cls, url):
+    """
+    clarifai.com uses fully qualified urls to resources.
+    They are in the format of:
+    https://clarifai.com/{user_id}/{app_id}/
+    """
+    url = url.replace("https://", "", 1).replace("http://", "", 1)
+    o = urlparse(url)
+    path = o.path
+    path = path.lstrip("/")
+    parts = path.split("/")
+    if len(parts) != 2:
+      raise ValueError(
+          "Provided url must have 2 parts after the domain name. These are: {user_id}/{app_id}")
+    return tuple(parts[1:])
+
+  @classmethod
   def split_clarifai_url(cls, url):
     """
     clarifai.com uses fully qualified urls to resources.

--- a/clarifai/urls/helper.py
+++ b/clarifai/urls/helper.py
@@ -70,9 +70,9 @@ class ClarifaiUrlHelper(object):
     path = o.path
     path = path.lstrip("/")
     parts = path.split("/")
-    if len(parts) != 2:
+    if len(parts) != 3:
       raise ValueError(
-          "Provided url must have 2 parts after the domain name. These are: {user_id}/{app_id}")
+          f"Provided url must have 2 parts after the domain name. The current parts are: {parts}")
     return tuple(parts[1:])
 
   @classmethod

--- a/tests/workflow/fixtures/single_branch_with_public_cropper_model_and_latest_version.yml
+++ b/tests/workflow/fixtures/single_branch_with_public_cropper_model_and_latest_version.yml
@@ -7,7 +7,7 @@ workflow:
           model_version_id: 34ce21a40cc24b6b96ffee54aabff139
     - id: cropper
       model:
-          model_id: margin-100-image-crop
+          model_id: margin-110-image-crop
 
       node_inputs:
         - node_id: detector


### PR DESCRIPTION
**Problem**

Users should be able to use the web URL e.g. `"https://clarifai.com/Isaac/let-me-see-if-this-works1"` to instantiate an App object.

Code snippet used:
```python
from clarifai.client.app import App
app = App("https://clarifai.com/Isaac/let-me-see-if-this-works1")
```

Actual Behaviour:
```
In [6]: app = App("https://clarifai.com/Isaac/let-me-see-if-this-works1")
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ in <module>:1                                                                                    │
│                                                                                                  │
│ /Users/isaacchung/virtualenv/v1/lib/python3.10/site-packages/clarifai/client/app.py:50 in        │
│ __init__                                                                                         │
│                                                                                                  │
│    47 │   if url and app_id:                                                                     │
│    48 │     raise UserError("You can only specify one of url or app_id.")                        │
│    49 │   if url:                                                                                │
│ ❱  50 │     user_id, app_id, _, _, _ = ClarifaiUrlHelper.split_clarifai_url(url)                 │
│    51 │     kwargs = {'user_id': user_id}                                                        │
│    52 │   self.kwargs = {**kwargs, 'id': app_id}                                                 │
│    53 │   self.app_info = resources_pb2.App(**self.kwargs)                                       │
│                                                                                                  │
│ /Users/isaacchung/virtualenv/v1/lib/python3.10/site-packages/clarifai/urls/helper.py:76 in       │
│ split_clarifai_url                                                                               │
│                                                                                                  │
│    73 │   path = path.lstrip("/")                                                                │
│    74 │   parts = path.split("/")                                                                │
│    75 │   if len(parts) != 5 and len(parts) != 7:                                                │
│ ❱  76 │     raise ValueError(                                                                    │
│    77 │   │     "Provided url must have 4 or 6 parts after the domain name. These are: {user_i   │
│    78 │     )                                                                                    │
│    79 │   user_id, app_id, resource_type, resource_id = parts[1:5]                               │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
ValueError: Provided url must have 4 or 6 parts after the domain name. These are: {user_id}/{app_id}/{resource_type}/{resource_id}/{resource_version_type}/{resource_version_id}
```

**Fix**

Use an app-specific url parser method to handle URLs that only have 3 parts (host, user_id, app_id).