### PR TITLE
Add RAG chat method

### DIFF
--- a/clarifai/client/workflow.py
+++ b/clarifai/client/workflow.py
@@ -75,7 +75,7 @@ class Workflow(Lister, BaseClient):
         output_config=self.output_config)
 
     if workflow_state_id:
-      request.workflow_state = resources_pb2.WorkFlowState(id=workflow_state_id)
+      request.workflow_state.id = workflow_state_id
 
     start_time = time.time()
     backoff_iterator = BackoffIterator()

--- a/clarifai/client/workflow.py
+++ b/clarifai/client/workflow.py
@@ -63,6 +63,7 @@ class Workflow(Lister, BaseClient):
 
     Args:
         inputs (list[Input]): The inputs to predict.
+        workflow_state_id (str): key for the workflow state cache that stores the workflow node predictions.
     """
     if len(inputs) > MAX_WORKFLOW_PREDICT_INPUTS:
       raise UserError(f"Too many inputs. Max is {MAX_WORKFLOW_PREDICT_INPUTS}."

--- a/clarifai/client/workflow.py
+++ b/clarifai/client/workflow.py
@@ -58,7 +58,7 @@ class Workflow(Lister, BaseClient):
     BaseClient.__init__(self, user_id=self.user_id, app_id=self.app_id, base=base_url, pat=pat)
     Lister.__init__(self)
 
-  def predict(self, inputs: List[Input]):
+  def predict(self, inputs: List[Input], workflow_state_id: str = None):
     """Predicts the workflow based on the given inputs.
 
     Args:
@@ -73,6 +73,9 @@ class Workflow(Lister, BaseClient):
         version_id=self.version.id,
         inputs=inputs,
         output_config=self.output_config)
+
+    if workflow_state_id:
+      request.workflow_state = resources_pb2.WorkFlowState(id=workflow_state_id)
 
     start_time = time.time()
     backoff_iterator = BackoffIterator()

--- a/clarifai/rag/rag.py
+++ b/clarifai/rag/rag.py
@@ -144,8 +144,8 @@ class RAG:
     """
     if client_manage_state:
       single_prompt = convert_messages_to_str(messages)
-      input_proto = Inputs._get_proto(text_pb=resources_pb2.Text(raw=single_prompt))
-      response = self._prompt_workflow.predict([input_proto], "text")
+      input_proto = Inputs._get_proto("", "", text_pb=resources_pb2.Text(raw=single_prompt))
+      response = self._prompt_workflow.predict([input_proto])
       messages.append(format_assistant_message(response.results[0].outputs[-1].data.text.raw))
       return messages
 
@@ -158,7 +158,7 @@ class RAG:
     chat_state_id = "init" if self.chat_state_id is None else self.chat_state_id
 
     # call predict
-    input_proto = Inputs._get_proto(text_pb=resources_pb2.Text(raw=message))
+    input_proto = Inputs._get_proto("", "", text_pb=resources_pb2.Text(raw=message))
     response = self._prompt_workflow.predict([input_proto], workflow_state_id=chat_state_id)
 
     # store chat state id

--- a/clarifai/rag/utils.py
+++ b/clarifai/rag/utils.py
@@ -1,0 +1,28 @@
+from typing import List
+
+
+## TODO: Make this token-aware.
+def convert_messages_to_str(messages: List[dict]) -> str:
+  """convert messages in OpenAI API format into a single string.
+
+    Args:
+        messages List[dict]: A list of dictionary in the following format:
+        ```
+        [
+          {"role": "user", "content": "Hello there."},
+          {"role": "assistant", "content": "Hi, I'm Claude. How can I help you?"},
+          {"role": "user", "content": "Can you explain LLMs in plain English?"},
+        ]
+        ```
+    """
+  final_str = ""
+  for msg in messages:
+    if "role" in msg and "content" in msg:
+      role = msg.get("role", "")
+      content = msg.get("content", "")
+      final_str += f"\n\n{role}: {content}"
+  return final_str
+
+
+def format_assistant_message(raw_text: str) -> dict:
+  return {"role": "assistant", "content": raw_text}

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -13,18 +13,23 @@ auth_obj = namedtuple("auth", "ui")
 
 @pytest.mark.requires_secrets
 class TestRAG:
-  workflow_url = ""
-  app_id = ""
 
-  def test_setup(self):
-    app = RAG.setup(user_id=CREATE_APP_USER_ID)
-    wf = app._prompt_workflow
-    assert len(wf.workflow_info.nodes) == 2
+  @classmethod
+  def setup_class(self):
+    self.rag = RAG.setup(user_id=CREATE_APP_USER_ID)
+    wf = self.rag._prompt_workflow
     auth = auth_obj(ui="https://clarifai.com")
     self.workflow_url = ClarifaiUrlHelper(auth).clarifai_url(wf.user_id, wf.app_id, "workflows",
                                                              wf.id)
-    self.app_id = app._app.id
 
-    ## test_from_existing_workflow
+  def test_setup_correct(self):
+    assert len(self.rag._prompt_workflow.workflow_info.nodes) == 2
+
+  def test_from_existing_workflow(self):
     app = RAG(workflow_url=self.workflow_url)
-    assert app._app.id == self.app_id
+    assert app._app.id == self.rag._app.id
+
+  def test_predict_client_manage_state(self):
+    messages = [{"role": "human", "content": "What is 1 + 1?"}]
+    new_messages = self.rag.chat(messages, client_manage_state=True)
+    assert len(new_messages) == 2

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -33,3 +33,9 @@ class TestRAG:
     messages = [{"role": "human", "content": "What is 1 + 1?"}]
     new_messages = self.rag.chat(messages, client_manage_state=True)
     assert len(new_messages) == 2
+
+  @pytest.mark.skip(reason="Not yet supported. Work in progress.")
+  def test_predict_server_manage_state(self):
+    messages = [{"role": "human", "content": "What is 1 + 1?"}]
+    new_messages = self.rag.chat(messages)
+    assert len(new_messages) == 1


### PR DESCRIPTION
## What
The chat method for RAG follows the openAI API format, i.e. it [expects messages as a list of dicts](https://docs.anthropic.com/claude/reference/messages_post) like:
```
[
          {"role": "user", "content": "Hello there."},
          {"role": "assistant", "content": "Hi, I'm Claude. How can I help you?"},
          {"role": "user", "content": "Can you explain LLMs in plain English?"},
]
```
This aligns with most if not all cloud LLM providers in terms of format.

### Notes

- Users can choose whether to manage chat state themselves or let us do it.
- Added workflow state support in workflow predict
- work is in progress for the actual backend change for `client_manage_state=false`. May consider adding "not implemented" for the moment and a test XFAIL
