### PR TITLE
Assert user_id for `RAG.setup()`

### DIFF
--- a/clarifai/rag/rag.py
+++ b/clarifai/rag/rag.py
@@ -61,6 +61,9 @@ class RAG:
         >>> from clarifai.rag import RAG
         >>> rag_agent = RAG.setup()
     """
+    if not user_id:
+      raise UserError(
+          "user_id must be provided. It can be found at https://clarifai.com/settings.")
     user = User(user_id=user_id, base_url=base_url, pat=pat)
     llm = Model(llm_url)
 


### PR DESCRIPTION
Missed check. Current behaviour:
```
In [15]: RAG.setup()
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ in <module>:1                                                                                    │
│                                                                                                  │
│ /Users/isaacchung/work/clarifai-python/clarifai/rag/rag.py:65 in setup                           │
│                                                                                                  │
│    62 │   │   >>> rag_agent = RAG.setup()                                                        │
│    63 │   """                                                                                    │
│    64 │   if not user_id:                                                                        │
│ ❱  65 │     raise UserError(                                                                     │
│    66 │   │     "user_id must be provided. It can be found at https://clarifai.com/settings.")   │
│    67 │   user = User(user_id=user_id, base_url=base_url, pat=pat)                               │
│    68 │   llm = Model(llm_url)                                                                   │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
UserError: user_id must be provided. It can be found at https://clarifai.com/settings.
```

Users must supply their user_id.