### PR TITLE
DEVX-330 - modified process_response_keys function to support metadata fields

### DIFF
--- a/clarifai/client/base.py
+++ b/clarifai/client/base.py
@@ -119,7 +119,12 @@ class BaseClient:
             value_s.update(value)
             value = value_s
           elif key in ['metadata']:
-            continue  # TODO Fix "app_duplication"
+            if isinstance(value, dict) and value != {}:
+              value_s = struct_pb2.Struct()
+              value_s.update(value)
+              value = value_s
+            else:
+              continue
           new_item[key] = convert_recursive(value)
         return new_item
       elif isinstance(item, list):


### PR DESCRIPTION
**Description :**

list_inputs function is not fetching metadata field since the process_response_keys function which used to convert the input response into object omits it. 

**Changes made :** 

- Modified the function to include metadata fields as well. 
- Tested with other functions which call this internally such as, list_workflows, list_apps, list_datasets, list_modules, list_models, list_annotations, list_concepts.

https://clarifai.atlassian.net/browse/DEVX-330 