### PR TITLE
Support case when existing app without workflow is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This is the official Python client for interacting with our powerful [API](https
   * [Smart Image Search](#smart-image-search)
   * [Smart Text Search](#smart-text-search)
   * [Filters](#filters)
-* **[RAG](#retrieval-augmented-generation-rag)**
+* **[Retrieval Augmented Generation (RAG)](#retrieval-augmented-generation-rag)**
 * **[More Examples](#pushpin-more-examples)**
 
 

--- a/clarifai/rag/rag.py
+++ b/clarifai/rag/rag.py
@@ -79,6 +79,9 @@ class RAG:
     if not user_id and app_url:
       app = App(url=app_url, pat=pat)
 
+    if user_id and app_url:
+      raise UserError("Must provide one of user_id or app_url, not both.")
+
     if not user_id and not app_url:
       raise UserError(
           "user_id or app_url must be provided. The user_id can be found at https://clarifai.com/settings."

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -31,8 +31,8 @@ class TestRAG:
     assert len(self.rag._prompt_workflow.workflow_info.nodes) == 2
 
   def test_from_existing_workflow(self):
-    app = RAG(workflow_url=self.workflow_url)
-    assert app._app.id == self.rag._app.id
+    agent = RAG(workflow_url=self.workflow_url)
+    assert agent._app.id == self.rag._app.id
 
   def test_predict_client_manage_state(self):
     messages = [{"role": "human", "content": "What is 1 + 1?"}]


### PR DESCRIPTION
## Problem
When users have an existing app with inputs, they currently do not have a way to start RAG via the RAG class. The setup method supports creating everything, including the app, from scratch. But it is possible that the data ingestion phase is too large to be replicated.

## Improvement
Add a parameter and checks in the `setup` method. Preview:
```python
from clarifai.rag import RAG
rag_agent = RAG.setup(app_url=YOUR_APP_URL)
rag_agent.chat(messages=[{"role":"human", "content":"What is Clarifai"}])
```