### PR TITLE
right step to install clarifai from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ Install from Source:
 ```bash
 git clone https://github.com/Clarifai/clarifai-python.git
 cd clarifai-python
-python3 -m venv env
-source env/bin/activate
-pip3 install -r requirements.txt
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python setup.py install
 ```
 
 


### PR DESCRIPTION
**What does this PR do?**
Adds/makes the amendment for right/working steps to install `clarifai` python package from source. 

**What is the ticket/issue associated with this PR?**
No ticket as I am posing as an Open-Source Contributor, rather than a Clarifai team/group member on Github.

**If None, add the motivation behind this PR?**
As I was experimenting with Clarifai upon my discovery of this awesome utility/ML tool, I realised contributing to Clarifai code base as a great idea. Thereafter, upon trying to install the clarifai cli from source, I realised that the steps had one line-of-code missing (or may be written better/crisper, as I have explained in the "Additional Notes"
The changes by-and-large allude towards the usage of `python setup.py install` as an additional/legitimate step, without which, the package `clarifai` doesn't really install/show up in the "pip freeze" of the libraries of that virtual env. 

**Any Notes associated w.r.t Implementation, Further Scope, Caveats associated with this PR?**
Ideally, `python setup.py install` should have taken care of the installation of necessary steps mentioned in the `requirements.txt` file, such that there's no explicit need to do:
```pip install -r requirements.txt```
rather just
```python setup.py install --user --prefix=```
refer this: SO answer https://stackoverflow.com/a/4495175
However, the issue of:
```
--- JPEG support available
*** OPENJPEG (JPEG2000) support not available
--- ZLIB (PNG/ZIP) support available
*** LIBIMAGEQUANT support not available
--- LIBTIFF support available
--- FREETYPE2 support available
*** RAQM (Text shaping) support not available
--- LITTLECMS2 support available
*** WEBP support not available
*** WEBPMUX support not available
--- XCB (X protocol) support available
--------------------------------------------------------------------
To add a missing option, make sure you have the required
library and headers.
See https://pillow.readthedocs.io/en/latest/installation.html#building-from-source

To check the build, run the selftest.py script.

error: Setup script exited with error: SandboxViolation: mkdir('/<path-to>/Library/Caches/com.apple.python/private/var/folders/t8/62vyl9097yl9z8nty9tphld00000gn/T/easy_install-idvlm9v9', 511) {}
```
still persisted. I therefore, left it to be another step after installation of `requirements.txt` which is otherwise supposedly redundant. 

As other minor changes, I believe:
§ virtualenv may be better named as/kept "hidden". Since `.env` may have ambiguous interpretation as an environments config, I chose to propose it as `.venv`. Q.E.D.
§ pip3 and python3 versions/locations, as the virtual env has been created with python3, anyways point to pip and python respectively, thus the redundant/explicit mention of "3" as suffix/version of python, taken off. 

**Has this PR been tested?If Yes, How?**
Yes, but only manually. Alternatively, it may be automated with some nice shell scripting to:
§ create a venv
§ activate that venv
§ run install of setup.py
§ grep appropriately in the "pip list" (or freeze) output

**Additional Notes?**
Dear Clarifai team, I am a seasoned Data, ML and platform engineer, with an enriching 10 years of experience of all-things-backend engineering, at scale, across various industry verticals, and largely championing solutions for ML usecases.
I had chanced upon this awesome tool, and also looked up open requisitions at Clarifai, which bear relevance to my profile and interests. 
Whilst it is love to contribute to open source rollouts of Clarifai, and I intend to do few more of contributions, I would be glad to be also considered as a part and parcel of Tech @ Clarifai. I am based out of the UAE, moving shortly to India, reachable on following contact coordinates:

> phone(whatsapp messages only) : +91-7899512408 
> google meet/zoom : [ksumeet40@gmail.com](ksumeet40@gmail.com)

Kindly let me know! More power to us all, and best wishes to everyone at Clarifai!