### PR TITLE
adding a rudimentary PR template under hidden .github dir

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**What does this PR do?**
+<br><br><br>
+**What is the ticket/issue associated with this PR?**
+<br><br><br>
+**If None, add the motivation behind this PR?**
+<br><br><br>
+**Any Notes associated w.r.t Implementation, Further Scope, Caveats associated with this PR?**
+<br><br><br>
+**Has this PR been tested?If Yes, How?**
+<br><br><br>
+**Additional Notes?**


### PR DESCRIPTION
**What does this PR do?**
Creates a PR template, available as a rudimentary template underneath `.github` folder vis-a-vis `pull_request_template.md`. The PR template kinda, exactly("oxymoron" (-:, because I have "\<br\>"s all over than newlines! ) resembles a template like this PR's

**What is the ticket/issue associated with this PR?**
No ticket as I am posing as an Open-Source Contributor, rather than a Clarifai team/group member on Github.

**If None, add the motivation behind this PR?**
Raising PRs in a template that is legible, more verbose and overarching leads to a better collaboration. Whilst this is aquick default template for a general PR, we can always have:
§ either such PR template enriched with other nuances like what issue this PR closes, any notes on reproducibility, any notes on a mandatory reviewer/team etc. 
§ create an array of PR templates, such that, one may choose to use an appropriate PR template, which may be a subjective/best effort call :-) 

**Any Notes associated w.r.t Implementation, Further Scope, Caveats associated with this PR?**
Reflecting on the aforementioned 2 points, to make raising PR a lesser pain for the reviewer, and more power to the team and spirit of collaboration. 
Albeit, for better legibility, the newlines may replace the \<br\> markdowns

**Has this PR been tested?If Yes, How?**
Yes, but manually again. I had merged this `.github/pull_request_template.md` to be available in the "master" codebase, and as I thereafter began opening a test PR, the PR context automatically showed up along the template proposed. 
<img width="1519" alt="Screenshot 2024-01-29 at 23 25 51" src="https://github.com/Clarifai/clarifai-python/assets/3143799/6d6299d0-203d-4942-bbdb-ed77613dbd3a">

**Additional Notes?**
Dear Clarifai team, I am a seasoned Data, ML and platform engineer, with an enriching 10 years of experience of all-things-backend engineering, at scale, across various industry verticals, and largely championing solutions for ML usecases.
I had chanced upon this awesome tool, and also looked up open requisitions at Clarifai, which bear relevance to my profile and interests.
Whilst it is love to contribute to open source rollouts of Clarifai, and I intend to do few more of contributions, I would be glad to be also considered as a part and parcel of Tech @ Clarifai. I am based out of the UAE, moving shortly to India, reachable on following contact coordinates:

phone(whatsapp messages only) : +91-7899512408
google meet/zoom : [ksumeet40@gmail.com](mailto:ksumeeet40@gmail.com)

Kindly let me know! More power to us all, and best wishes to everyone at Clarifai!