### PR TITLE
[DEVX-381]: Modified train params.yaml file structure

### DIFF
--- a/clarifai/utils/model_train.py
+++ b/clarifai/utils/model_train.py
@@ -43,7 +43,7 @@ def response_to_model_params(response: MultiModelTypeResponse,
           continue
         #checking the template model type fields
         if _path[-1] != "template":
-          if _path[0] == 'train_info' :
+          if _path[0] == 'train_info':
             try:
               params["train_params"][_path[-1]] = modeltypefield['defaultValue']
             except Exception:
@@ -55,7 +55,7 @@ def response_to_model_params(response: MultiModelTypeResponse,
             except Exception:
               params["inference_params"][_path[-1]] = None
           if _path[0] == 'output_info' and _path[1] == 'output_config':
-              params["concepts_mutually_exclusive"] = (modeltypefield['defaultValue'])
+            params["concepts_mutually_exclusive"] = (modeltypefield['defaultValue'])
         else:
           if 'modelTypeEnumOptions' in modeltypefield.keys():
             #check given template is valid
@@ -123,8 +123,7 @@ def params_parser(params_dict: dict, concepts: List = None) -> Dict[str, Any]:
     train_dict['output_info']['params'].update(params_dict["inference_params"])
   if 'concepts_mutually_exclusive' in params_dict.keys():
     train_dict['output_info']['output_config'] = resources_pb2.OutputConfig(
-      concepts_mutually_exclusive = params_dict['concepts_mutually_exclusive']
-  )
+        concepts_mutually_exclusive=params_dict['concepts_mutually_exclusive'])
   train_dict['output_info'] = resources_pb2.OutputInfo(**train_dict['output_info'])
 
   return train_dict

--- a/clarifai/utils/model_train.py
+++ b/clarifai/utils/model_train.py
@@ -101,12 +101,6 @@ def params_parser(params_dict: dict, concepts: List = None) -> Dict[str, Any]:
       custom_config = python_file.read()
     params_dict['train_params']['custom_config'] = custom_config
 
-  if 'base_embed_model' in params_dict['train_params'].keys():
-    train_dict["input_info"] = dict()
-    train_dict["input_info"]['base_embed_model'] = params_dict['train_params']['base_embed_model']
-    train_dict['input_info'] = resources_pb2.InputInfo(**train_dict['input_info'])
-    del params_dict['train_params']['base_embed_model']
-
   train_dict["train_info"]['params'].update(params_dict["train_params"])
   if 'dataset_id' in params_dict.keys():
     train_dict["train_info"]['params']['dataset_id'] = params_dict['dataset_id']

--- a/clarifai/utils/model_train.py
+++ b/clarifai/utils/model_train.py
@@ -43,7 +43,7 @@ def response_to_model_params(response: MultiModelTypeResponse,
           continue
         #checking the template model type fields
         if _path[-1] != "template":
-          if _path[0] == 'train_info' or _path[0] == 'input_info':
+          if _path[0] == 'train_info' :
             try:
               params["train_params"][_path[-1]] = modeltypefield['defaultValue']
             except Exception:
@@ -54,6 +54,8 @@ def response_to_model_params(response: MultiModelTypeResponse,
               params["inference_params"][_path[-1]] = modeltypefield['defaultValue']
             except Exception:
               params["inference_params"][_path[-1]] = None
+          if _path[0] == 'output_info' and _path[1] == 'output_config':
+              params["concepts_mutually_exclusive"] = (modeltypefield['defaultValue'])
         else:
           if 'modelTypeEnumOptions' in modeltypefield.keys():
             #check given template is valid
@@ -119,6 +121,10 @@ def params_parser(params_dict: dict, concepts: List = None) -> Dict[str, Any]:
   if 'inference_params' in params_dict.keys():
     train_dict["output_info"]['params'] = Struct()
     train_dict['output_info']['params'].update(params_dict["inference_params"])
+  if 'concepts_mutually_exclusive' in params_dict.keys():
+    train_dict['output_info']['output_config'] = resources_pb2.OutputConfig(
+      concepts_mutually_exclusive = params_dict['concepts_mutually_exclusive']
+  )
   train_dict['output_info'] = resources_pb2.OutputInfo(**train_dict['output_info'])
 
   return train_dict


### PR DESCRIPTION
<!---
The PR description should include WHAT, WHY, HOW it does things and how this PR is tested.
-->

<!-- ### What -->
<!--
You should try to state the WHAT in PR title only.
Your PR title should describe in short WHAT this PR does, e.g. "[AA-1] Add new Clarifai cool feature".
Uncomment the `### What` section above, if you decide to add more details about WHAT this PR does.
For example, you may choose to describe the WHAT in more detail in the below cases.
* If the PR title is too short to include what your PR does;
* If your PR does more than one thing, the title may not have enough space to include everything. In this case, consider creating multiple PRs to separate work and make it easier for everybody to understand. Alternatively, mention a list of things what this PR does in this section.
-->



### Why
<!-- Why is this PR trying to accomplish said thing? This is useful to understand your intention why this code should be merged to master. -->
* This PR mainly focussed on addressing the concern raised in this ticket https://clarifai.atlassian.net/browse/DEVX-381.


### How
<!-- How is this PR trying to accomplish said thing? This is useful to understand the details of the code. The code reviewer will check this section to assist them with code review. -->
* Removed the key `base_embed_model` from params.yaml file, since the model training by default considers the base embed model which is set for the app and no need to define it again in params file.
* Added `concepts_mutually_exclusive` parameter which is there in UI but missing from the existing yaml template.

![Screenshot 2024-03-19 at 5 57 55 PM](https://github.com/Clarifai/clarifai-python/assets/143642606/7c6245d8-68d0-4dcf-91f1-48d8ff1f13ca)


### Tests
<!-- How is this PR tested? Write some tests to convince yourself and the reviewer that your code works. Sometimes, no tests are necessary, but we should always ask the question "Can I add some tests for this PR?". -->
* Test was done with curl endpoint which fetches the model training info after it was trained.
```bash
curl -X GET "https://api.clarifai.com/v2/users/mogith-p-n/apps/transfer_learn/models/image_transfer_learn/versions/b9c41a42a29e4f639d7eacf115c2e3fe" \
    -H "Authorization: Key PAT"
```
Response
```
{"status":{"code":10000,"description":"Ok","req_id":"501d3c2f1740ea9eba624f20940e10cd"},"model_version":{"id":"b9c41a42a29e4f639d7eacf115c2e3fe","created_at":"2024-03-15T13:29:28.469350Z","status":{"code":21100,"description":"Model is trained and ready"},"active_concept_count":4,"total_input_count":20,"train_stats":{"loss_curve":[{"cost":1.3873892},{"epoch":25,"global_step":4,"cost":0.5949107},{"epoch":51,"global_step":8,"cost":0.0036175046},{"epoch":76,"global_step":12,"cost":0.0018137831},{"epoch":102,"global_step":16,"cost":0.0020436822},{"epoch":128,"global_step":20,"cost":0.0021939636},{"epoch":153,"global_step":24,"cost":0.0022796458},{"epoch":179,"global_step":28,"cost":0.0023247986},{"epoch":204,"global_step":32,"cost":0.0023464388},{"epoch":230,"global_step":36,"cost":0.0023552317}]},"completed_at":"2024-03-15T13:29:31.172301Z","visibility":{"gettable":10},"app_id":"transfer_learn","user_id":"mogith-p-n","metadata":{},"output_info":{"output_config":{"concepts_mutually_exclusive":true,"max_concepts":0,"min_value":0},"message":"Show output_info with: GET [/models/](https://file+.vscode-resource.vscode-cdn.net/models/){model_id}/output_info","params":{"max_concepts":20,"min_value":0,"select_concepts":[]}},"input_info":{"base_embed_model":{"id":"CLIP-ViT-L-14-DataComp-XL-s13B-b90K","app_id":"main","model_version":{"id":"54772a548e6f42509cb1fd9fc43762bb"},"user_id":"clarifai","model_type_id":"multimodal-embedder","toolkits":[],"use_cases":[],"languages":[],"languages_full":[],"check_consents":[]}},"train_info":{"params":{"dataset_id":"","dataset_version_id":"","enrich_dataset":"Automatic"}},"import_info":{}}}
```

### Notes
<!-- Add any additional notes here. -->
*

