### PR TITLE
Add VERSION and requirements.txt to setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 global-include *.css
 include clarifai/modules/style.css
 recursive-include clarifai *
+include VERSION requirements.txt


### PR DESCRIPTION
These files aren't currently being included in the sdist, giving e.g.

```
$ python setup.py --help
...
FileNotFoundError: [Errno 2] No such file or directory: 'VERSION'
```

Looks like this has been an issue since 9.9.1.

This also means you can't use the more recent `pypa/build` module to build a wheel for this package:

```
$ python -m build
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - setuptools >= 40.8.0
* Getting build dependencies for sdist...
* Building sdist...
...
copying files to clarifai-10.2.1...
copying LICENSE -> clarifai-10.2.1
copying MANIFEST.in -> clarifai-10.2.1
copying README.md -> clarifai-10.2.1
copying pyproject.toml -> clarifai-10.2.1
copying setup.py -> clarifai-10.2.1
...
* Building wheel from sdist
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - setuptools >= 40.8.0
* Getting build dependencies for wheel...
Traceback (most recent call last):
...
FileNotFoundError: [Errno 2] No such file or directory: 'VERSION'

ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```