### PR TITLE
DEVX-426: get_upload_status overriding log_warnings table in log file issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,15 @@ dataset.upload_dataset(dataloader=coco_dataloader, get_upload_status=True)
 #Try upload and record the failed outputs in log file.
 from clarifai.datasets.upload.utils import load_module_dataloader
 cifar_dataloader = load_module_dataloader('./image_classification/cifar10')
-dataset.upload_dataset(dataloader=cifar_dataloader, log_warnings =True)
+
+dataset.upload_dataset(dataloader=cifar_dataloader,
+                       get_upload_status=True,
+                       log_warnings =True)
 
 #Retry upload from logs for `upload_dataset`
+# Set retry_duplicates to True if you want to ingest failed inputs due to duplication issues. by default it is set to 'False'.
 dataset.retry_upload_from_logs(dataloader=cifar_dataloader, log_file_path='log_file.log',
-                               retry_duplicates=False,
+                               retry_duplicates=True,
                                log_warnings=True)
 
 #upload text from csv

--- a/clarifai/client/dataset.py
+++ b/clarifai/client/dataset.py
@@ -416,9 +416,6 @@ class Dataset(Lister, BaseClient):
       log_warnings (bool): True if you want to save log warnings in a file
       kwargs: Additional keyword arguments for retry uploading functionality..
     """
-    #add file handler to log warnings
-    if log_warnings:
-      add_file_handler(self.logger, f"Dataset_Upload{str(int(datetime.now().timestamp()))}.log")
     #set batch size and task
     self.batch_size = min(self.batch_size, batch_size)
     self.task = dataloader.task
@@ -442,6 +439,9 @@ class Dataset(Lister, BaseClient):
     if get_upload_status:
       pre_upload_stats = self.get_upload_status(pre_upload=True)
 
+    #add file handler to log warnings
+    if log_warnings:
+      add_file_handler(self.logger, f"Dataset_Upload{str(int(datetime.now().timestamp()))}.log")
     self._data_upload(dataset_obj, **kwargs)
 
     if get_upload_status:


### PR DESCRIPTION
<!---
The PR description should include WHAT, WHY, HOW it does things and how this PR is tested.
-->

<!-- ### What -->
<!--
You should try to state the WHAT in PR title only.
Your PR title should describe in short WHAT this PR does, e.g. "[AA-1] Add new Clarifai cool feature".
Uncomment the `### What` section above, if you decide to add more details about WHAT this PR does.
For example, you may choose to describe the WHAT in more detail in the below cases.
* If the PR title is too short to include what your PR does;
* If your PR does more than one thing, the title may not have enough space to include everything. In this case, consider creating multiple PRs to separate work and make it easier for everybody to understand. Alternatively, mention a list of things what this PR does in this section.
-->



### Why
<!-- Why is this PR trying to accomplish said thing? This is useful to understand your intention why this code should be merged to master. -->
* This PR is in reference to the ticket --> https://clarifai.atlassian.net/browse/DEVX-426.

### How
<!-- How is this PR trying to accomplish said thing? This is useful to understand the details of the code. The code reviewer will check this section to assist them with code review. -->
* Issue: When trying `get_upload_status` args along with `log_warnings` in `dataset.upload_dataset` function we are facing an issue where the upload status table overrides the log file since `self.logger` is shared between both loggers.

### Tests
<!-- How is this PR tested? Write some tests to convince yourself and the reviewer that your code works. Sometimes, no tests are necessary, but we should always ask the question "Can I add some tests for this PR?". -->
* No tests, Tested locally with all parameters and batch size to ensure it fixes the problem.


