### PR TITLE
[EAGLE-4201]: json logging

### DIFF
--- a/clarifai/utils/logging.py
+++ b/clarifai/utils/logging.py
@@ -300,14 +300,14 @@ class JsonFormatter(logging.Formatter):
     if level:
       fields['level'] = level.lower()
 
-    # Get the thread local data from gRPC (proto/utils/common.py)
+    # Get the thread local data
     req_id = getattr(thread_log_info, 'req_id', None)
     if req_id:
       fields['req_id'] = req_id
     orig_req_id = getattr(thread_log_info, 'orig_req_id', None)
     if orig_req_id:
       fields['orig_req_id'] = orig_req_id
-    # Get the thread local data from gRPC (proto/utils/common.py)
+    # Get the thread local data
     requester = getattr(thread_log_info, 'requester', None)
     if requester:
       fields['requester'] = requester

--- a/clarifai/utils/logging.py
+++ b/clarifai/utils/logging.py
@@ -1,4 +1,12 @@
+import datetime
+import json
 import logging
+import os
+import socket
+import sys
+import threading
+import time
+import traceback
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Union
 
@@ -10,6 +18,41 @@ from rich.traceback import install
 from rich.tree import Tree
 
 install()
+
+# For the json logger.
+JSON_LOGGER_NAME = "clarifai-json"
+JSON_LOG_KEY = 'msg'
+JSON_DEFAULT_CHAR_LENGTH = 400
+FIELD_BLACKLIST = [
+    'msg', 'message', 'account', 'levelno', 'created', 'threadName', 'name', 'processName',
+    'module', 'funcName', 'msecs', 'relativeCreated', 'pathname', 'args', 'thread', 'process'
+]
+
+# Create thread local storage that the format() call below uses.
+# This is only used by the json_logger in the appropriate CLARIFAI_DEPLOY levels.
+thread_log_info = threading.local()
+
+
+def get_logger_context():
+  return thread_log_info.__dict__
+
+
+def set_logger_context(**kwargs):
+  thread_log_info.__dict__.update(kwargs)
+
+
+def clear_logger_context():
+  thread_log_info.__dict__.clear()
+
+
+def restore_logger_context(context):
+  thread_log_info.__dict__.clear()
+  thread_log_info.__dict__.update(context)
+
+
+def get_req_id_from_context():
+  ctx = get_logger_context()
+  return ctx.get('req_id', '')
 
 
 def display_workflow_tree(nodes_data: List[Dict]) -> None:
@@ -84,12 +127,19 @@ def _configure_logger(name: str, logger_level: Union[int, str] = logging.NOTSET)
   for handler in logger.handlers[:]:
     logger.removeHandler(handler)
 
-  # Add the new rich handler and formatter
-  handler = RichHandler(
-      rich_tracebacks=True, log_time_format="%Y-%m-%d %H:%M:%S", console=Console(width=255))
-  formatter = logging.Formatter('%(name)s:  %(message)s')
-  handler.setFormatter(formatter)
-  logger.addHandler(handler)
+  if os.getenv('ENABLE_JSON_LOGGER', 'false') == 'true':
+    # Add the json handler and formatter
+    handler = logging.StreamHandler()
+    formatter = JsonFormatter()
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+  else:
+    # Add the new rich handler and formatter
+    handler = RichHandler(
+        rich_tracebacks=True, log_time_format="%Y-%m-%d %H:%M:%S", console=Console(width=255))
+    formatter = logging.Formatter('%(name)s:  %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
 
 
 def get_logger(logger_level: Union[int, str] = logging.NOTSET,
@@ -151,3 +201,153 @@ def display_concept_relations_tree(relations_dict: Dict[str, Any]) -> None:
     for child in children:
       tree.add(child)
     rprint(tree)
+
+
+def _default_json_default(obj):
+  """
+  Handle objects that could not be serialized to JSON automatically.
+
+  Coerce everything to strings.
+  All objects representing time get output as ISO8601.
+  """
+  if isinstance(obj, (datetime.datetime, datetime.date, datetime.time)):
+    return obj.isoformat()
+  else:
+    return _object_to_string_with_truncation(obj)
+
+
+def _object_to_string_with_truncation(obj) -> str:
+  """
+  Truncate object string.
+
+  It's preferred to not log objects that could cause triggering this function,
+  It's better to extract important parts form them and log them as regular Python types,
+  like str or int, which won't be passed to this functon.
+
+  This message brings additional information to the logs
+  that could help to find and fix truncation cases.
+  - hardcoded part of the message could be used for the looking all entries in logs
+  - obj class could help with detail investigation
+  """
+
+  objstr = str(obj)
+  if len(objstr) > JSON_DEFAULT_CHAR_LENGTH:
+    type_name = type(obj).__name__
+    truncated = objstr[:JSON_DEFAULT_CHAR_LENGTH]
+    objstr = f"{truncated}...[{type_name} was truncated, len={len(objstr)} chars]"
+  return objstr
+
+
+class JsonFormatter(logging.Formatter):
+
+  def __init__(self,
+               fmt=None,
+               datefmt=None,
+               style='%',
+               json_cls=None,
+               json_default=_default_json_default):
+    """
+    :param fmt: Config as a JSON string, allowed fields;
+           extra: provide extra fields always present in logs
+           source_host: override source host name
+    :param datefmt: Date format to use (required by logging.Formatter
+        interface but not used)
+    :param json_cls: JSON encoder to forward to json.dumps
+    :param json_default: Default JSON representation for unknown types,
+                         by default coerce everything to a string
+    """
+
+    if fmt is not None:
+      self._fmt = json.loads(fmt)
+    else:
+      self._fmt = {}
+    self.json_default = json_default
+    self.json_cls = json_cls
+    if 'extra' not in self._fmt:
+      self.defaults = {}
+    else:
+      self.defaults = self._fmt['extra']
+    if 'source_host' in self._fmt:
+      self.source_host = self._fmt['source_host']
+    else:
+      try:
+        self.source_host = socket.gethostname()
+      except Exception:
+        self.source_host = ""
+
+  def _build_fields(self, defaults, fields):
+    """Return provided fields including any in defaults
+    """
+    return dict(list(defaults.get('@fields', {}).items()) + list(fields.items()))
+
+  # Override the format function to fit Clarifai
+  def format(self, record):
+    fields = record.__dict__.copy()
+
+    # logger.info({...}) directly.
+    if isinstance(record.msg, dict):
+      fields.update(record.msg)
+      fields.pop('msg')
+      msg = ""
+    else:  # logger.info("message", {...})
+      if isinstance(record.args, dict):
+        fields.update(record.args)
+      msg = record.getMessage()
+    for k in FIELD_BLACKLIST:
+      fields.pop(k, None)
+    # Rename 'levelname' to 'level' and make the value lowercase to match Go logs
+    level = fields.pop('levelname', None)
+    if level:
+      fields['level'] = level.lower()
+
+    # Get the thread local data from gRPC (proto/utils/common.py)
+    req_id = getattr(thread_log_info, 'req_id', None)
+    if req_id:
+      fields['req_id'] = req_id
+    orig_req_id = getattr(thread_log_info, 'orig_req_id', None)
+    if orig_req_id:
+      fields['orig_req_id'] = orig_req_id
+    # Get the thread local data from gRPC (proto/utils/common.py)
+    requester = getattr(thread_log_info, 'requester', None)
+    if requester:
+      fields['requester'] = requester
+
+    user_id = getattr(thread_log_info, 'user_id', None)
+    if requester:
+      fields['user_id'] = user_id
+
+    if hasattr(thread_log_info, 'start_time'):
+      #pylint: disable=no-member
+      fields['duration_ms'] = (time.time() - thread_log_info.start_time) * 1000
+
+    if 'exc_info' in fields:
+      if fields['exc_info']:
+        formatted = traceback.format_exception(*fields['exc_info'])
+        fields['exception'] = formatted
+      fields.pop('exc_info')
+
+    if 'exc_text' in fields and not fields['exc_text']:
+      fields.pop('exc_text')
+
+    logr = self.defaults.copy()
+
+    logr.update({
+        JSON_LOG_KEY: msg,
+        '@timestamp': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+    })
+
+    logr.update(fields)
+
+    try:
+      return json.dumps(logr, default=self.json_default, cls=self.json_cls)
+    except Exception:
+
+      type, value, tb = sys.exc_info()
+      return json.dumps(
+          {
+              "msg": f"Fail to format log {type.__name__}({value}), {logr}",
+              "formatting_traceback": "\n".join(traceback.format_tb(tb)),
+          },
+          default=self.json_default,
+          cls=self.json_cls,
+      )

--- a/clarifai/utils/logging.py
+++ b/clarifai/utils/logging.py
@@ -324,6 +324,7 @@ class JsonFormatter(logging.Formatter):
       if fields['exc_info']:
         formatted = traceback.format_exception(*fields['exc_info'])
         fields['exception'] = formatted
+
       fields.pop('exc_info')
 
     if 'exc_text' in fields and not fields['exc_text']:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -4,7 +4,7 @@ import logging
 
 from rich.logging import RichHandler
 
-from clarifai.utils.logging import JsonFormatter, _get_library_name, get_logger
+from clarifai.utils.logging import JsonFormatter, _get_library_name, get_logger, set_logger_context
 
 
 def test_get_logger():
@@ -46,9 +46,22 @@ def test_json_logger():
   # assert the ts was within 10 seconds of now (in UTC time)
   assert abs(datetime.datetime.utcnow() - datetime.datetime.strptime(
       ts, "%Y-%m-%dT%H:%M:%S.%fZ")) < datetime.timedelta(seconds=10)
-
   assert result['filename'] == filename
   assert result['msg'] == msg
   assert result['lineno'] == lineno
   assert result['stack_info'] == sinfo
   assert result['level'] == "info"
+  assert 'req_id' not in result
+
+  req_id = "test_req_id"
+  set_logger_context(req_id=req_id)
+  json_line = jf.format(r)
+  result = json.loads(json_line)
+  assert abs(datetime.datetime.utcnow() - datetime.datetime.strptime(
+      ts, "%Y-%m-%dT%H:%M:%S.%fZ")) < datetime.timedelta(seconds=10)
+  assert result['filename'] == filename
+  assert result['msg'] == msg
+  assert result['lineno'] == lineno
+  assert result['stack_info'] == sinfo
+  assert result['level'] == "info"
+  assert result['req_id'] == req_id

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,8 +1,10 @@
+import datetime
+import json
 import logging
 
 from rich.logging import RichHandler
 
-from clarifai.utils.logging import _get_library_name, get_logger
+from clarifai.utils.logging import JsonFormatter, _get_library_name, get_logger
 
 
 def test_get_logger():
@@ -17,3 +19,36 @@ def test_get_logger_defaults():
   assert logger.level == logging.NOTSET
   assert logger.name == _get_library_name()
   assert isinstance(logger.handlers[0], RichHandler)
+
+
+def test_json_logger():
+  filename = "testy.py"
+  msg = "testy"
+  lineno = 1
+  sinfo = "testf2"
+  r = logging.LogRecord(
+      name="testy",
+      level=logging.INFO,
+      pathname=filename,
+      lineno=lineno,
+      msg=msg,
+      args=(),
+      exc_info=None,
+      func="testf",
+      sinfo=sinfo)
+  jf = JsonFormatter()
+  # format the record as a json line.
+  json_line = jf.format(r)
+  result = json.loads(json_line)
+  # parse timestamp of format "2024-09-24T22:06:49.573038Z" in @timestamp field.
+  assert result["@timestamp"] is not None
+  ts = result["@timestamp"]
+  # assert the ts was within 10 seconds of now (in UTC time)
+  assert abs(datetime.datetime.utcnow() - datetime.datetime.strptime(
+      ts, "%Y-%m-%dT%H:%M:%S.%fZ")) < datetime.timedelta(seconds=10)
+
+  assert result['filename'] == filename
+  assert result['msg'] == msg
+  assert result['lineno'] == lineno
+  assert result['stack_info'] == sinfo
+  assert result['level'] == "info"


### PR DESCRIPTION
Added a json logger so it's convenient to get logs into logging stacks. Logs will look like: 

```
{"msg": "Loop iteration: 0 for thread 140485041844224", "@timestamp": "2024-09-24T21:31:15.411793Z", "filename": "test.py", "stack_info": null, "lineno": 214, "level": "info", "req_id": "runner-084a853704604c948bf226911f3cb0c6", "orig_req_id": "runner-084a853704604c948bf226911f3cb0c6"}
```
when env var `ENABLE_JSON_LOGGER=true`