### PR TITLE
fixing streamlit query_params call to remove error w/streamlit >=1.30

### DIFF
--- a/clarifai/client/auth/helper.py
+++ b/clarifai/client/auth/helper.py
@@ -136,7 +136,7 @@ class ClarifaiAuthHelper:
 
     # Then add in the query params.
     try:
-      auth.add_streamlit_query_params(st.experimental_get_query_params())
+      auth.add_streamlit_query_params(dict(st.query_params))
     except Exception as e:
       st.error(e)
       st.stop()


### PR DESCRIPTION
New versions of streamlit lead to error text boxes when using the removed st.experimental_get_query_params() call. It has been replaced by st.query_params which is not callable, so it's passed to a dict to replicate the functionality.