### PR TITLE
[PR-295] Ignore pattern for original folder

### DIFF
--- a/clarifai/runners/utils/loader.py
+++ b/clarifai/runners/utils/loader.py
@@ -53,7 +53,10 @@ class HuggingFaceLoader:
           logger.error("Model %s not found on Hugging Face" % (self.repo_id))
           return False
         snapshot_download(
-            repo_id=self.repo_id, local_dir=checkpoint_path, local_dir_use_symlinks=False)
+            repo_id=self.repo_id,
+            local_dir=checkpoint_path,
+            local_dir_use_symlinks=False,
+            ignore_patterns="original/*")
       except Exception as e:
         logger.error(f"Error downloading model checkpoints {e}")
         return False

--- a/clarifai/runners/utils/loader.py
+++ b/clarifai/runners/utils/loader.py
@@ -39,7 +39,7 @@ class HuggingFaceLoader:
   def download_checkpoints(self, checkpoint_path: str):
     # throw error if huggingface_hub wasn't installed
     try:
-      from huggingface_hub import snapshot_download
+      from huggingface_hub import list_repo_files, snapshot_download
     except ImportError:
       raise ImportError(self.HF_DOWNLOAD_TEXT)
     if os.path.exists(checkpoint_path) and self.validate_download(checkpoint_path):
@@ -52,11 +52,17 @@ class HuggingFaceLoader:
         if not is_hf_model_exists:
           logger.error("Model %s not found on Hugging Face" % (self.repo_id))
           return False
+
+        ignore_patterns = None  # Download everything.
+        repo_files = list_repo_files(repo_id=self.repo_id, token=self.token)
+        if any(f.endswith(".safetensors") for f in repo_files):
+          logger.info(f"SafeTensors found in {self.repo_id}, downloading only .safetensors files.")
+          ignore_patterns = ["original/*", "*.pth", "*.bin"]
         snapshot_download(
             repo_id=self.repo_id,
             local_dir=checkpoint_path,
             local_dir_use_symlinks=False,
-            ignore_patterns="original/*")
+            ignore_patterns=ignore_patterns)
       except Exception as e:
         logger.error(f"Error downloading model checkpoints {e}")
         return False


### PR DESCRIPTION
### Why

original folder contains files that are provided by the original uploader. HF creates their own checkpoints, hence we do not need this folder

### How

Added an ignore_pattern to snapshot_download