### PR TITLE
remove triton requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,10 @@ clarifai-grpc>=11.0.0
 clarifai-protocol>=0.0.14
 numpy>=1.22.0
 tqdm>=4.65.0
-tritonclient>=2.34.0
 rich>=13.4.2
 PyYAML>=6.0.1
 schema==0.7.5
 Pillow>=9.5.0
-inquirerpy==0.3.4
 tabulate>=0.9.0
 fsspec==2024.6.1
 click==8.1.7


### PR DESCRIPTION
When I removed triton examples I didn't remove their reqs. This will prevent bloat that tritonclient brings with it. 

I'd love to get rid of the dependency on numpy as it's large. We could switch to just "np.array" string based type assertions in the several places we expect a numpy type coming in and then maybe inline import numpy. I see it used in a couple of runners thing and eval things but nothing else so it should be possible to remove it ideally as it's a decent sized dependency for the base SDK. Pillow is another that is used for datasets and runners data handler. Wonder if there are flavors of the SDK we can have like clarifai[data] that installs extra stuff like numpy and pillow if you're dealing with evals or want wrappers for runners?

Tabulate and schema are two others that are even less important than numpy. tabulate is only used to log errors in evals @phatvo9 maybe you can remove the need for that? 

Schema is some validation stuff maybe @sanjaychelliah you have context on why we need that? 

