### PR TITLE
use the non-runtime path for tests

### DIFF
--- a/clarifai/runners/models/model_run_locally.py
+++ b/clarifai/runners/models/model_run_locally.py
@@ -482,8 +482,10 @@ def main(model_path,
     sys.exit(1)
   manager = ModelRunLocally(model_path)
   # get whatever stage is in config.yaml to force download now
+  # also always write to where upload/build wants to, not the /tmp folder that runtime stage uses
   _, _, _, when = manager.builder._validate_config_checkpoints()
-  manager.builder.download_checkpoints(stage=when)
+  manager.builder.download_checkpoints(
+      stage=when, checkpoint_path_override=manager.builder.checkpoint_path)
   if inside_container:
     if not manager.is_docker_installed():
       sys.exit(1)

--- a/tests/runners/test_download_checkpoints.py
+++ b/tests/runners/test_download_checkpoints.py
@@ -62,8 +62,10 @@ def test_download_checkpoints(dummy_runner_models_dir):
   model_builder = ModelBuilder(model_folder_path, download_validation_only=True)
   # defaults to runtime stage which matches config.yaml not having a when field.
   # get whatever stage is in config.yaml to force download now
+  # also always write to where upload/build wants to, not the /tmp folder that runtime stage uses
   _, _, _, when = model_builder._validate_config_checkpoints()
-  checkpoint_dir = model_builder.download_checkpoints(stage=when)
+  checkpoint_dir = model_builder.download_checkpoints(
+      stage=when, checkpoint_path=model_builder.checkpoint_path)
   assert checkpoint_dir == DEFAULT_RUNTIME_DOWNLOAD_PATH
 
   # This doesn't have when in it's config.yaml so build.
@@ -71,7 +73,9 @@ def test_download_checkpoints(dummy_runner_models_dir):
   model_builder = ModelBuilder(model_folder_path, download_validation_only=True)
   # defaults to runtime stage which matches config.yaml not having a when field.
   # get whatever stage is in config.yaml to force download now
+  # also always write to where upload/build wants to, not the /tmp folder that runtime stage uses
   _, _, _, when = model_builder._validate_config_checkpoints()
-  checkpoint_dir = model_builder.download_checkpoints(stage=when)
+  checkpoint_dir = model_builder.download_checkpoints(
+      stage=when, checkpoint_path=model_builder.checkpoint_path)
   assert checkpoint_dir == os.path.join(
       os.path.dirname(__file__), "hf_mbart_model", "1", "checkpoints")

--- a/tests/runners/test_download_checkpoints.py
+++ b/tests/runners/test_download_checkpoints.py
@@ -5,7 +5,6 @@ import tempfile
 import pytest
 
 from clarifai.runners.models.model_builder import ModelBuilder
-from clarifai.runners.utils.const import DEFAULT_RUNTIME_DOWNLOAD_PATH
 from clarifai.runners.utils.loader import HuggingFaceLoader
 
 MODEL_ID = "timm/mobilenetv3_small_100.lamb_in1k"
@@ -65,8 +64,8 @@ def test_download_checkpoints(dummy_runner_models_dir):
   # also always write to where upload/build wants to, not the /tmp folder that runtime stage uses
   _, _, _, when = model_builder._validate_config_checkpoints()
   checkpoint_dir = model_builder.download_checkpoints(
-      stage=when, checkpoint_path=model_builder.checkpoint_path)
-  assert checkpoint_dir == DEFAULT_RUNTIME_DOWNLOAD_PATH
+      stage=when, checkpoint_path_override=model_builder.checkpoint_path)
+  assert checkpoint_dir == model_builder.checkpoint_path
 
   # This doesn't have when in it's config.yaml so build.
   model_folder_path = os.path.join(os.path.dirname(__file__), "hf_mbart_model")
@@ -76,6 +75,6 @@ def test_download_checkpoints(dummy_runner_models_dir):
   # also always write to where upload/build wants to, not the /tmp folder that runtime stage uses
   _, _, _, when = model_builder._validate_config_checkpoints()
   checkpoint_dir = model_builder.download_checkpoints(
-      stage=when, checkpoint_path=model_builder.checkpoint_path)
+      stage=when, checkpoint_path_override=model_builder.checkpoint_path)
   assert checkpoint_dir == os.path.join(
       os.path.dirname(__file__), "hf_mbart_model", "1", "checkpoints")

--- a/tests/runners/test_model_run_locally-container.py
+++ b/tests/runners/test_model_run_locally-container.py
@@ -81,8 +81,12 @@ def test_hf_docker_build_and_test_container(hf_model_run_locally):
   This test will be skipped if Docker is not installed.
   """
 
+  # get whatever stage is in config.yaml to force download now
+  # also always write to where upload/build wants to, not the /tmp folder that runtime stage uses
   # Download the checkpoints for the model
-  hf_model_run_locally.builder.download_checkpoints()
+  _, _, _, when = hf_model_run_locally.builder._validate_config_checkpoints()
+  hf_model_run_locally.builder.download_checkpoints(
+      stage=when, checkpoint_path=hf_model_run_locally.builder.checkpoint_path)
 
   # Test if Docker is installed
   assert hf_model_run_locally.is_docker_installed(), "Docker not installed, skipping."

--- a/tests/runners/test_model_run_locally-container.py
+++ b/tests/runners/test_model_run_locally-container.py
@@ -86,7 +86,7 @@ def test_hf_docker_build_and_test_container(hf_model_run_locally):
   # Download the checkpoints for the model
   _, _, _, when = hf_model_run_locally.builder._validate_config_checkpoints()
   hf_model_run_locally.builder.download_checkpoints(
-      stage=when, checkpoint_path=hf_model_run_locally.builder.checkpoint_path)
+      stage=when, checkpoint_path_override=hf_model_run_locally.builder.checkpoint_path)
 
   # Test if Docker is installed
   assert hf_model_run_locally.is_docker_installed(), "Docker not installed, skipping."

--- a/tests/runners/test_model_run_locally.py
+++ b/tests/runners/test_model_run_locally.py
@@ -174,7 +174,7 @@ def test_hf_test_model_success(hf_model_run_locally):
   # also always write to where upload/build wants to, not the /tmp folder that runtime stage uses
   _, _, _, when = hf_model_run_locally.builder._validate_config_checkpoints()
   hf_model_run_locally.builder.download_checkpoints(
-      stage=when, checkpoint_path=hf_model_run_locally.builder.checkpoint_path)
+      stage=when, checkpoint_path_override=hf_model_run_locally.builder.checkpoint_path)
   hf_model_run_locally.create_temp_venv()
   hf_model_run_locally.install_requirements()
 

--- a/tests/runners/test_model_run_locally.py
+++ b/tests/runners/test_model_run_locally.py
@@ -171,8 +171,10 @@ def test_hf_test_model_success(hf_model_run_locally):
   This calls the script's test_model method, which runs a subprocess.
   """
   # get whatever stage is in config.yaml to force download now
+  # also always write to where upload/build wants to, not the /tmp folder that runtime stage uses
   _, _, _, when = hf_model_run_locally.builder._validate_config_checkpoints()
-  hf_model_run_locally.builder.download_checkpoints(stage=when)
+  hf_model_run_locally.builder.download_checkpoints(
+      stage=when, checkpoint_path=hf_model_run_locally.builder.checkpoint_path)
   hf_model_run_locally.create_temp_venv()
   hf_model_run_locally.install_requirements()
 


### PR DESCRIPTION
Avoid the runtime path as it'll clobber /tmp over and over write checkpoints into model_path/1/checkpoints as before for test-locally and unit tests.