### PR TITLE
fixed user id bug in generate_by_bytes function

### DIFF
--- a/clarifai/client/model.py
+++ b/clarifai/client/model.py
@@ -832,8 +832,11 @@ class Model(Lister, BaseClient):
         raise UserError(
             "User ID is required for model prediction with deployment ID, please provide user_id in the method call."
         )
+      if not user_id:
+        user_id = os.environ.get('CLARIFAI_USER_ID')
       runner_selector = Deployment.get_runner_selector(
           user_id=user_id, deployment_id=deployment_id)
+
     elif compute_cluster_id and nodepool_id:
       if not user_id and not os.environ.get('CLARIFAI_USER_ID'):
         raise UserError(


### PR DESCRIPTION
<!---
The PR description should include WHAT, WHY, HOW it does things and how this PR is tested.
-->

<!-- ### What -->
<!--
You should try to state the WHAT in PR title only.
Your PR title should describe in short WHAT this PR does, e.g. "[AA-1] Add new Clarifai cool feature".
Uncomment the `### What` section above, if you decide to add more details about WHAT this PR does.
For example, you may choose to describe the WHAT in more detail in the below cases.
* If the PR title is too short to include what your PR does;
* If your PR does more than one thing, the title may not have enough space to include everything. In this case, consider creating multiple PRs to separate work and make it easier for everybody to understand. Alternatively, mention a list of things what this PR does in this section.
-->



### Why
<!-- Why is this PR trying to accomplish said thing? This is useful to understand your intention why this code should be merged to master. -->
* Generate by bytes function wasn't working for the dedicated nodepool inference calls because the function is not considering user_id from the environment variable.
