### PR TITLE
Removed HF loader config.json validation for all clarifai Model type ids

### DIFF
--- a/clarifai/runners/models/model_builder.py
+++ b/clarifai/runners/models/model_builder.py
@@ -480,6 +480,7 @@ class ModelBuilder:
     if not self.config.get("checkpoints"):
       logger.info("No checkpoints specified in the config file")
       return path
+    clarifai_model_type_id = self.config.get('model').get('model_type_id')
 
     loader_type, repo_id, hf_token, when = self._validate_config_checkpoints()
     if stage not in ["build", "upload", "runtime"]:
@@ -492,7 +493,8 @@ class ModelBuilder:
 
     success = True
     if loader_type == "huggingface":
-      loader = HuggingFaceLoader(repo_id=repo_id, token=hf_token)
+      loader = HuggingFaceLoader(
+          repo_id=repo_id, token=hf_token, model_type_id=clarifai_model_type_id)
       # for runtime default to /tmp path
       if stage == "runtime" and checkpoint_path_override is None:
         checkpoint_path_override = self.default_runtime_checkpoint_path()

--- a/clarifai/runners/utils/loader.py
+++ b/clarifai/runners/utils/loader.py
@@ -6,6 +6,7 @@ import shutil
 
 import requests
 
+from clarifai.runners.utils.const import CONCEPTS_REQUIRED_MODEL_TYPE
 from clarifai.utils.logging import logger
 
 
@@ -13,9 +14,10 @@ class HuggingFaceLoader:
 
   HF_DOWNLOAD_TEXT = "The 'huggingface_hub' package is not installed. Please install it using 'pip install huggingface_hub'."
 
-  def __init__(self, repo_id=None, token=None):
+  def __init__(self, repo_id=None, token=None, model_type_id=None):
     self.repo_id = repo_id
     self.token = token
+    self.clarifai_model_type_id = model_type_id
     if token:
       if self.validate_hftoken(token):
         try:
@@ -109,7 +111,10 @@ class HuggingFaceLoader:
       from huggingface_hub import file_exists, repo_exists
     except ImportError:
       raise ImportError(self.HF_DOWNLOAD_TEXT)
-    return repo_exists(self.repo_id) and file_exists(self.repo_id, 'config.json')
+    if self.clarifai_model_type_id in CONCEPTS_REQUIRED_MODEL_TYPE:
+      return repo_exists(self.repo_id) and file_exists(self.repo_id, 'config.json')
+    else:
+      return repo_exists(self.repo_id)
 
   def validate_download(self, checkpoint_path: str):
     # check if model exists on HF


### PR DESCRIPTION
<!---
The PR description should include WHAT, WHY, HOW it does things and how this PR is tested.
-->

<!-- ### What -->
<!--
You should try to state the WHAT in PR title only.
Your PR title should describe in short WHAT this PR does, e.g. "[AA-1] Add new Clarifai cool feature".
Uncomment the `### What` section above, if you decide to add more details about WHAT this PR does.
For example, you may choose to describe the WHAT in more detail in the below cases.
* If the PR title is too short to include what your PR does;
* If your PR does more than one thing, the title may not have enough space to include everything. In this case, consider creating multiple PRs to separate work and make it easier for everybody to understand. Alternatively, mention a list of things what this PR does in this section.
-->



### Why
<!-- Why is this PR trying to accomplish said thing? This is useful to understand your intention why this code should be merged to master. -->
* In SDK while validating HF checkpoints from config.yaml, we are doing a check to validate whether `config.json` present inside the `repo_id`.

* This is to essentially fetch concepts for image classification and segmentation type tasks, which is irrelevant for LLM and VLM models. Due to this some GGUF models from HF couldn’t able to be uploaded since it doesn’t have config.json in the repo.

### How
<!-- How is this PR trying to accomplish said thing? This is useful to understand the details of the code. The code reviewer will check this section to assist them with code review. -->
* By just using the validation step to check if the current model type id is in `CONCEPTS_REQUIRED_MODEL_TYPE` list and only checks for `config.json` if it passes the condition.

### Tests
<!-- How is this PR tested? Write some tests to convince yourself and the reviewer that your code works. Sometimes, no tests are necessary, but we should always ask the question "Can I add some tests for this PR?". -->
* Not added at this point. But will add in future with dummy model with model type id in `CONCEPTS_REQUIRED_MODEL_TYPE`  without` config.json` and a lightweight `text-to-text` model without `config.json`.
