### PR TITLE
[PR-499] check for pat first

### DIFF
--- a/clarifai/runners/models/model_builder.py
+++ b/clarifai/runners/models/model_builder.py
@@ -184,8 +184,16 @@ class ModelBuilder:
     resp = self.client.STUB.GetApp(service_pb2.GetAppRequest(user_app_id=self.client.user_app_id))
     if resp.status.code == status_code_pb2.SUCCESS:
       return True
+    if resp.status.code == status_code_pb2.CONN_KEY_INVALID:
+      logger.error(
+          f"Invalid PAT provided for user {self.client.user_app_id.user_id} and app {self.client.user_app_id.app_id}"
+      )
+      return False
     logger.error(
         f"Error checking API {self._base_api} for user app {self.client.user_app_id.user_id}/{self.client.user_app_id.app_id}. Error code: {resp.status.code}"
+    )
+    logger.error(
+        f"App {self.client.user_app_id.app_id} not found for user {self.client.user_app_id.user_id}"
     )
     return False
 
@@ -207,9 +215,6 @@ class ModelBuilder:
     assert model.get('id') != "", "model_id cannot be empty in the config file"
 
     if not self._check_app_exists():
-      logger.error(
-          f"App {self.client.user_app_id.app_id} not found for user {self.client.user_app_id.user_id}"
-      )
       sys.exit(1)
 
   def _validate_config(self):


### PR DESCRIPTION
### Why

When we check for the existence for the app we tell the user `app does not exists` even if the request fails due to wrong PAT.

### How

Check for status code, and error correspondingly if it is due to PAT