### PR TITLE
Updating runner selector in Model Class

### DIFF
--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -266,14 +266,19 @@ def predict(ctx, config, model_id, user_id, app_id, model_url, file_path, url, b
       raise ValueError(
           "Either --compute_cluster_id & --nodepool_id or --deployment_id must be provided.")
   if model_url:
-    model = Model(url=model_url, pat=ctx.obj['pat'], base_url=ctx.obj['base_url'])
+    model = Model(url=model_url, pat=ctx.obj['pat'], base_url=ctx.obj['base_url'],
+                  compute_cluster_id=compute_cluster_id,
+                  nodepool_id=nodepool_id, deployment_id=deployment_id)
   else:
     model = Model(
         model_id=model_id,
         user_id=user_id,
         app_id=app_id,
         pat=ctx.obj['pat'],
-        base_url=ctx.obj['base_url'])
+        base_url=ctx.obj['base_url'],
+        compute_cluster_id=compute_cluster_id,
+        nodepool_id=nodepool_id,
+        deployment_id=deployment_id)
 
   if inference_params:
     inference_params = json.loads(inference_params)
@@ -284,18 +289,12 @@ def predict(ctx, config, model_id, user_id, app_id, model_url, file_path, url, b
     model_prediction = model.predict_by_filepath(
         filepath=file_path,
         input_type=input_type,
-        compute_cluster_id=compute_cluster_id,
-        nodepool_id=nodepool_id,
-        deployment_id=deployment_id,
         inference_params=inference_params,
         output_config=output_config)
   elif url:
     model_prediction = model.predict_by_url(
         url=url,
         input_type=input_type,
-        compute_cluster_id=compute_cluster_id,
-        nodepool_id=nodepool_id,
-        deployment_id=deployment_id,
         inference_params=inference_params,
         output_config=output_config)
   elif bytes:
@@ -303,9 +302,6 @@ def predict(ctx, config, model_id, user_id, app_id, model_url, file_path, url, b
     model_prediction = model.predict_by_bytes(
         input_bytes=bytes,
         input_type=input_type,
-        compute_cluster_id=compute_cluster_id,
-        nodepool_id=nodepool_id,
-        deployment_id=deployment_id,
         inference_params=inference_params,
         output_config=output_config)  ## TO DO: Add support for input_id
   click.echo(model_prediction)

--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -266,9 +266,13 @@ def predict(ctx, config, model_id, user_id, app_id, model_url, file_path, url, b
       raise ValueError(
           "Either --compute_cluster_id & --nodepool_id or --deployment_id must be provided.")
   if model_url:
-    model = Model(url=model_url, pat=ctx.obj['pat'], base_url=ctx.obj['base_url'],
-                  compute_cluster_id=compute_cluster_id,
-                  nodepool_id=nodepool_id, deployment_id=deployment_id)
+    model = Model(
+        url=model_url,
+        pat=ctx.obj['pat'],
+        base_url=ctx.obj['base_url'],
+        compute_cluster_id=compute_cluster_id,
+        nodepool_id=nodepool_id,
+        deployment_id=deployment_id)
   else:
     model = Model(
         model_id=model_id,

--- a/clarifai/client/model.py
+++ b/clarifai/client/model.py
@@ -85,13 +85,11 @@ class Model(Lister, BaseClient):
         token=token,
         root_certificates_path=root_certificates_path)
     Lister.__init__(self)
-    self.runner_selector = (
-        self._get_runner_selector(
-            deployment_id=deployment_id,
-            nodepool_id=nodepool_id,
-            compute_cluster_id=compute_cluster_id
-        ) if any([deployment_id, nodepool_id, compute_cluster_id]) else None
-    )
+    self.runner_selector = (self._get_runner_selector(
+        deployment_id=deployment_id,
+        nodepool_id=nodepool_id,
+        compute_cluster_id=compute_cluster_id)
+                            if any([deployment_id, nodepool_id, compute_cluster_id]) else None)
 
   def list_training_templates(self) -> List[str]:
     """Lists all the training templates for the model type.
@@ -417,10 +415,7 @@ class Model(Lister, BaseClient):
           model_id=self.id,
           **dict(self.kwargs, model_version=model_version_info))
 
-  def predict(self,
-              inputs: List[Input],
-              inference_params: Dict = {},
-              output_config: Dict = {}):
+  def predict(self, inputs: List[Input], inference_params: Dict = {}, output_config: Dict = {}):
     """Predicts the model based on the given inputs.
 
     Args:
@@ -572,9 +567,7 @@ class Model(Lister, BaseClient):
       input_proto = Inputs.get_input_from_bytes("", audio_bytes=input_bytes)
 
     return self.predict(
-        inputs=[input_proto],
-        inference_params=inference_params,
-        output_config=output_config)
+        inputs=[input_proto], inference_params=inference_params, output_config=output_config)
 
   def predict_by_url(self,
                      url: str,
@@ -611,14 +604,9 @@ class Model(Lister, BaseClient):
       input_proto = Inputs.get_input_from_url("", audio_url=url)
 
     return self.predict(
-        inputs=[input_proto],
-        inference_params=inference_params,
-        output_config=output_config)
+        inputs=[input_proto], inference_params=inference_params, output_config=output_config)
 
-  def generate(self,
-               inputs: List[Input],
-               inference_params: Dict = {},
-               output_config: Dict = {}):
+  def generate(self, inputs: List[Input], inference_params: Dict = {}, output_config: Dict = {}):
     """Generate the stream output on model based on the given inputs.
 
     Args:
@@ -739,9 +727,7 @@ class Model(Lister, BaseClient):
       input_proto = Inputs.get_input_from_bytes("", audio_bytes=input_bytes)
 
     return self.generate(
-        inputs=[input_proto],
-        inference_params=inference_params,
-        output_config=output_config)
+        inputs=[input_proto], inference_params=inference_params, output_config=output_config)
 
   def generate_by_url(self,
                       url: str,
@@ -779,9 +765,7 @@ class Model(Lister, BaseClient):
       input_proto = Inputs.get_input_from_url("", audio_url=url)
 
     return self.generate(
-        inputs=[input_proto],
-        inference_params=inference_params,
-        output_config=output_config)
+        inputs=[input_proto], inference_params=inference_params, output_config=output_config)
 
   def _req_iterator(self, input_iterator: Iterator[List[Input]], runner_selector: RunnerSelector):
     for inputs in input_iterator:
@@ -907,9 +891,7 @@ class Model(Lister, BaseClient):
           yield [Inputs.get_input_from_bytes("", audio_bytes=input_bytes)]
 
     return self.stream(
-        inputs=input_generator(),
-        inference_params=inference_params,
-        output_config=output_config)
+        inputs=input_generator(), inference_params=inference_params, output_config=output_config)
 
   def stream_by_url(self,
                     url_iterator: Iterator[str],
@@ -947,9 +929,7 @@ class Model(Lister, BaseClient):
           yield [Inputs.get_input_from_url("", audio_url=url)]
 
     return self.stream(
-        inputs=input_generator(),
-        inference_params=inference_params,
-        output_config=output_config)
+        inputs=input_generator(), inference_params=inference_params, output_config=output_config)
 
   def _override_model_version(self, inference_params: Dict = {}, output_config: Dict = {}) -> None:
     """Overrides the model version.
@@ -981,9 +961,10 @@ class Model(Lister, BaseClient):
                                                    service_pb2.ListConceptsRequest, request_data)
     return [concept_info['concept_id'] for concept_info in all_concepts_infos]
 
-  def _get_runner_selector(self, deployment_id: str = None,
+  def _get_runner_selector(self,
+                           deployment_id: str = None,
                            compute_cluster_id: str = None,
-                           nodepool_id:str = None) -> RunnerSelector:
+                           nodepool_id: str = None) -> RunnerSelector:
     """Gets the runner selector for the model.
     Args:
         deployment_id (str): The deployment ID to use for the model.
@@ -994,8 +975,7 @@ class Model(Lister, BaseClient):
         runner_selector (RunnerSelector): The runner selector for the model.
     """
     # Get UserID
-    request = service_pb2.GetUserRequest(
-        user_app_id=resources_pb2.UserAppIDSet(user_id='me'))
+    request = service_pb2.GetUserRequest(user_app_id=resources_pb2.UserAppIDSet(user_id='me'))
     response = self._grpc_request(self.STUB.GetUser, request)
     if response.status.code != status_code_pb2.SUCCESS:
       raise Exception(f"Get User failed with response {response.status!r}")


### PR DESCRIPTION
<!---
The PR description should include WHAT, WHY, HOW it does things and how this PR is tested.
-->

<!-- ### What -->
<!--
You should try to state the WHAT in PR title only.
Your PR title should describe in short WHAT this PR does, e.g. "[AA-1] Add new Clarifai cool feature".
Uncomment the `### What` section above, if you decide to add more details about WHAT this PR does.
For example, you may choose to describe the WHAT in more detail in the below cases.
* If the PR title is too short to include what your PR does;
* If your PR does more than one thing, the title may not have enough space to include everything. In this case, consider creating multiple PRs to separate work and make it easier for everybody to understand. Alternatively, mention a list of things what this PR does in this section.
-->



# Why
<!-- Why is this PR trying to accomplish said thing? This is useful to understand your intention why this code should be merged to master. -->

## Blocker for Integrations to use CO params
   -  Model.predict() doesn't accept **deployment_id**, **runner_id**, **compute_cluster_id**. Instead it has **runner_selector** which is very tough for a new user to import and pass it to the `predict`, `generate` and `stream` functions.
  - - In integrations and batch predictions, we use model.predict() method. So its not possible to pass the CO params directly. Reference: [Langchain Integration](https://github.com/langchain-ai/langchain/blob/83b66cb9166972dc358590097441a5028c59e033/libs/community/langchain_community/llms/clarifai.py#L182)

## Ease of Use
  - More user friendly way to use deployed model when compared to the existing flow. 
       -  Existing flow

```python
from clarifai.client.model import Model

model = Model('https://clarifai.com/xai/chat-completion/models/grok-3')

prediction = model.predict_by_bytes('What is AI', nodepool_id = ' ', compute_cluster_id = ' ')

generation = model.generate_by_bytes('What is AI', nodepool_id = ' ', compute_cluster_id = ' ')

stream = model.stream(['What is AI'], nodepool_id = ' ', compute_cluster_id = ' ')

```

Now for each deployment , we can have separate model object
      
 ```python
from clarifai.client.model import Model

model = Model('https://clarifai.com/xai/chat-completion/models/grok-3',  nodepool_id = ' ', compute_cluster_id = ' ')

prediction = model.predict_by_bytes('What is AI')

generation = model.generate_by_bytes('What is AI')

stream = model.stream(['What is AI'])

```

## User_id Bug
- Debugged a known issue: Community model's ID is being passed to the runner selector if deployment user ID and model's user Id are different, like the below example

 ```python
model = Model('https://clarifai.com/xai/chat-completion/models/grok-3',  user_id = 'sanjay')
```
Ticket: https://clarifai.atlassian.net/browse/WFP-913

# Notes
<!-- Add any additional notes here. -->
## Breaking change
* CO params removed from `Model.predict_by_bytes()`, `Model.predict_by_url()`, `Model.predict_by_filepath()`, `Model.generate_by_bytes()`, `Model.generate_by_url()`, `Model.generate_by_filepath()`, `Model.stream_by_bytes()`, `Model.stram_by_url()`, `Model.stream_by_filepath()` functions. Instead it was added to Model init.


# Tests
<!-- How is this PR tested? Write some tests to convince yourself and the reviewer that your code works. Sometimes, no tests are necessary, but we should always ask the question "Can I add some tests for this PR?". -->
* Modified the existing tests


