### PR TITLE
Removed unused argument

### DIFF
--- a/clarifai/runners/models/visual_classifier_class.py
+++ b/clarifai/runners/models/visual_classifier_class.py
@@ -52,7 +52,7 @@ class VisualClassifierClass(ModelClass):
 
     @staticmethod
     def process_concepts(
-        logits: torch.Tensor, threshold: float, model_labels: Dict[int, str]
+        logits: torch.Tensor, model_labels: Dict[int, str]
     ) -> List[List[Concept]]:
         """Convert model logits into a structured format of concepts.
 


### PR DESCRIPTION
This pull request modifies the `process_concepts` method in the `clarifai/runners/models/visual_classifier_class.py` file to simplify its signature by removing the unused `threshold` parameter.

Code simplification:

* [`clarifai/runners/models/visual_classifier_class.py`](diffhunk://#diff-b7d9d0ad39e2f453568bfcc1a6d08ce834c812ea4874e4a7a7cca00d87c59b50L55-R55): Removed the `threshold` parameter from the `process_concepts` method as it was not being used, simplifying the method signature.