### PR TITLE
[EAGLE-6395]: Ensure cpu_limit is parsed as string

### DIFF
--- a/clarifai/runners/models/model_builder.py
+++ b/clarifai/runners/models/model_builder.py
@@ -550,6 +550,9 @@ class ModelBuilder:
             "inference_compute_info not found in the config file"
         )
         inference_compute_info = self.config.get('inference_compute_info')
+        # Ensure cpu_limit is a string if it exists and is an int
+        if 'cpu_limit' in inference_compute_info and isinstance(inference_compute_info['cpu_limit'], int):
+            inference_compute_info['cpu_limit'] = str(inference_compute_info['cpu_limit'])
         return json_format.ParseDict(inference_compute_info, resources_pb2.ComputeInfo())
 
     def check_model_exists(self):


### PR DESCRIPTION
The protobuf library expects string values for fields like cpu_limit. This change ensures that if cpu_limit is an integer in the YAML configuration, it is converted to a string before being processed by `json_format.ParseDict`.

Fixes issue when specifying whole integer number of cores during upload from CLI.
