### PR TITLE
[PR-386] default to num_threads first

### DIFF
--- a/clarifai/runners/server.py
+++ b/clarifai/runners/server.py
@@ -28,7 +28,7 @@ def main():
     parser.add_argument(
         '--pool_size',
         type=int,
-        default=32,
+        default=os.environ.get('CLARIFAI_NUM_THREADS', 32),
         help="The number of threads to use for the gRPC server.",
         choices=range(1, 129),
     )  # pylint: disable=range-builtin-not-iterating


### PR DESCRIPTION
### Why
The gRPC server mode and runner mode had inconsistent thread configuration defaults. The gRPC server used a hardcoded default of 32 threads for `pool_size`, while the runner mode respected the `CLARIFAI_NUM_THREADS` environment variable. This inconsistency made it difficult for users to configure thread scaling uniformly across different deployment modes.

### How
- Updated the `--pool_size` argument default from hardcoded `32` to `os.environ.get('CLARIFAI_NUM_THREADS', 32)`
- Both gRPC server mode (`--grpc` flag) and runner mode (default) now use the same `CLARIFAI_NUM_THREADS` environment variable as their configuration source
- Maintains backward compatibility by keeping 32 as the fallback default when the environment variable is not set

### Tests
- [ ] Verify gRPC server starts with correct thread pool size when `CLARIFAI_NUM_THREADS` is set
- [ ] Verify runner mode continues to work as expected
- [ ] Confirm default behavior (32 threads) when `CLARIFAI_NUM_THREADS` is not set
- [ ] Test command line override still works (`--pool_size` argument)

### Notes
- This is a backward-compatible change that only affects behavior when `CLARIFAI_NUM_THREADS` is explicitly set
- Runner mode still gives precedence to `config.yaml` over environment variables, while gRPC mode uses the environment variable directly
- Consider future work to align the precedence order completely between