### PR TITLE
[EAGLE-6403]: Display plan limits message for local dev runners

### DIFF
--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -641,6 +641,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 """)
     logger.info(snippet)
 
+    logger.info("Reminder: The Community Plan has a limit of 2 runner hours per month. Upgrade to the Developer Plan for unlimited runner hours.")
     logger.info("Now starting the local dev runner...")
 
     # This reads the config.yaml from the model_path so we alter it above first.


### PR DESCRIPTION
### Why
* Adds a reminder message about plan limits when running local dev runner.
