### PR TITLE
[EAGLE-6403]: 1 default thread for local dev runner

### DIFF
--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -730,6 +730,8 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
     # This reads the config.yaml from the model_path so we alter it above first.
     serve(
+        pool_size=1, # limit 1 for local dev runner
+        num_threads=1, # limit 1 for local dev runner
         model_path,
         user_id=user_id,
         compute_cluster_id=compute_cluster_id,

--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -407,8 +407,16 @@ def run_locally(model_path, port, mode, keep_env, keep_image, skip_dockerfile=Fa
     required=False,
     default=".",
 )
+@click.option(
+    "--pool_size",
+    type=int,
+    is_flag=True,
+    default=1,  # default to 1 thread for local dev runner to avoid rapid depletion of compute time.
+    show_default=True,
+    help="The number of threads to use. On community plan, the compute time allocation is drained at a rate proportional to the number of threads.",
+)  # pylint: disable=range-builtin-not-iterating
 @click.pass_context
-def local_dev(ctx, model_path):
+def local_dev(ctx, model_path, pool_size):
     """Run the model as a local dev runner to help debug your model connected to the API or to
     leverage local compute resources manually. This relies on many variables being present in the env
     of the currently selected context. If they are not present then default values will be used to
@@ -730,9 +738,9 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
     # This reads the config.yaml from the model_path so we alter it above first.
     serve(
-        pool_size=1, # limit 1 for local dev runner
-        num_threads=1, # limit 1 for local dev runner
         model_path,
+        pool_size=pool_size,
+        num_threads=pool_size,
         user_id=user_id,
         compute_cluster_id=compute_cluster_id,
         nodepool_id=nodepool_id,

--- a/clarifai/runners/server.py
+++ b/clarifai/runners/server.py
@@ -81,6 +81,7 @@ def serve(
     model_path,
     port=8000,
     pool_size=32,
+    num_threads=0,
     max_queue_size=10,
     max_msg_length=1024 * 1024 * 1024,
     enable_tls=False,
@@ -98,7 +99,8 @@ def serve(
 
     # `num_threads` can be set in config.yaml or via the environment variable CLARIFAI_NUM_THREADS="<integer>".
     # Note: The value in config.yaml takes precedence over the environment variable.
-    num_threads = builder.config.get("num_threads")
+    if num_threads == 0:
+        num_threads = builder.config.get("num_threads")
     # Setup the grpc server for local development.
     if grpc:
         # initialize the servicer with the runner so that it gets the predict(), generate(), stream() classes.


### PR DESCRIPTION
Add flag default 1 for local dev runner threads. This helps keep the community plan at 2 hours of compute time usage. 