### PR TITLE
Fixed Model Template Import &  Return Issues

### DIFF
--- a/clarifai/cli/templates/model_templates.py
+++ b/clarifai/cli/templates/model_templates.py
@@ -31,7 +31,7 @@ class MyModel(ModelClass):
         """This is the method that will be called when the runner is run. It takes in an input and returns an output."""
         # TODO: please fill in
         # Implement your prediction logic here
-        pass  # Replace with your actual logic
+        return "This is a placeholder response. Please implement your model logic."
 
     @ModelClass.method
     def generate(
@@ -45,7 +45,7 @@ class MyModel(ModelClass):
         """Example yielding a streamed response."""
         # TODO: please fill in
         # Implement your generation logic here
-        pass # Replace with your actual logic
+        yield "This is a placeholder response. Please implement your model logic."
 '''
 
 
@@ -104,7 +104,7 @@ def get_openai_model_class_template() -> str:
     return '''from typing import List
 from openai import OpenAI
 from clarifai.runners.models.openai_class import OpenAIModelClass
-from clarifai.runners.util.data_utils import Param
+from clarifai.runners.utils.data_utils import Param
 from clarifai.runners.utils.openai_convertor import build_openai_messages
 
 class MyModel(OpenAIModelClass):


### PR DESCRIPTION
This pull request updates the `clarifai/cli/templates/model_templates.py` file to provide placeholder implementations for prediction and generation methods and fixes an import path typo. Below are the key changes:

### Placeholder Implementations for Model Methods:
* Updated the `predict` method to return a placeholder response instead of a `pass` statement.
* Updated the `generate` method to yield a placeholder response instead of a `pass` statement.

### Bug Fix:
* Corrected the import path for `Param` from `clarifai.runners.util.data_utils` to `clarifai.runners.utils.data_utils`.