### PR TITLE
[PR-716]: Improve Handling for PAT and USER_ID

### DIFF
--- a/clarifai/cli/base.py
+++ b/clarifai/cli/base.py
@@ -159,7 +159,7 @@ def env(ctx_obj):
 @click.pass_context
 def login(ctx, api_url, user_id):
     """Login command to set PAT and other configurations."""
-    from clarifai.utils.cli import validate_pat_token
+    from clarifai.utils.cli import validate_context_auth
 
     name = input('context name (default: "default"): ')
     user_id = user_id if user_id is not None else input('user id: ')
@@ -168,17 +168,8 @@ def login(ctx, api_url, user_id):
         'ENVVAR',
     )
 
-    # Validate the PAT token if it's not "ENVVAR"
-    if pat != "ENVVAR":
-        print("Validating PAT token...")
-        is_valid, error_message = validate_pat_token(pat, user_id, api_url)
-
-        if not is_valid:
-            print(f"❌ PAT token validation failed: {error_message}")
-            print("Please check your token and try again.")
-            return  # Exit without saving the configuration
-        else:
-            print("✓ PAT token is valid")
+    # Validate the Context Credentials
+    validate_context_auth(pat, user_id, api_url)
 
     context = Context(
         name,
@@ -194,7 +185,7 @@ def login(ctx, api_url, user_id):
     ctx.obj.current_context = context.name
 
     ctx.obj.to_yaml()
-    print(f"✓ Configuration saved successfully for context '{context.name}'")
+    logger.info(f"Configuration saved successfully for context '{context.name}'")
 
 
 @cli.group(cls=AliasedGroup)
@@ -225,10 +216,10 @@ def create(
     pat=None,
 ):
     """Create a new context"""
-    from clarifai.utils.cli import validate_pat_token
+    from clarifai.utils.cli import validate_context_auth
 
     if name in ctx.obj.contexts:
-        print(f'{name} already exists')
+        logger.info(f'"{name}" context already exists')
         sys.exit(1)
     if not user_id:
         user_id = input('user id: ')
@@ -242,22 +233,13 @@ def create(
             'ENVVAR',
         )
 
-    # Validate the PAT token if it's not "ENVVAR"
-    if pat != "ENVVAR":
-        print("Validating PAT token...")
-        is_valid, error_message = validate_pat_token(pat, user_id, base_url)
-
-        if not is_valid:
-            print(f"❌ PAT token validation failed: {error_message}")
-            print("Please check your token and try again.")
-            return  # Exit without saving the configuration
-        else:
-            print("✓ PAT token is valid")
+    # Validate the Context Credentials
+    validate_context_auth(pat, user_id, base_url)
 
     context = Context(name, CLARIFAI_USER_ID=user_id, CLARIFAI_API_BASE=base_url, CLARIFAI_PAT=pat)
     ctx.obj.contexts[context.name] = context
     ctx.obj.to_yaml()
-    print(f"✓ Context '{name}' created successfully")
+    logger.info(f"Context '{name}' created successfully")
 
 
 # write a click command to delete a context

--- a/clarifai/cli/base.py
+++ b/clarifai/cli/base.py
@@ -185,7 +185,9 @@ def login(ctx, api_url, user_id):
     ctx.obj.current_context = context.name
 
     ctx.obj.to_yaml()
-    logger.info(f"Configuration saved successfully for context '{context.name}'")
+    logger.info(
+        f"Login successful and Configuration saved successfully for context '{context.name}'"
+    )
 
 
 @cli.group(cls=AliasedGroup)

--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import sys
 import tempfile
 
 import click
@@ -475,7 +474,7 @@ def local_runner(ctx, model_path, pool_size):
     logger.info(f"Current user_id: {user_id}")
     if not user_id:
         logger.error(f"User with ID '{user_id}' not found. Use 'clarifai login' to setup context.")
-        sys.exit(1)
+        raise click.Abort()
     pat = ctx.obj.current.pat
     display_pat = pat_display(pat) if pat else ""
     logger.info(f"Current PAT: {display_pat}")
@@ -483,7 +482,7 @@ def local_runner(ctx, model_path, pool_size):
         logger.error(
             "Personal Access Token (PAT) not found. Use 'clarifai login' to setup context."
         )
-        sys.exit(1)
+        raise click.Abort()
     user = User(user_id=user_id, pat=ctx.obj.current.pat, base_url=ctx.obj.current.api_base)
     logger.debug("Checking if a local runner compute cluster exists...")
 

--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -1,10 +1,11 @@
 import os
 import shutil
+import sys
 import tempfile
 
 import click
 
-from clarifai.cli.base import cli
+from clarifai.cli.base import cli, pat_display
 from clarifai.utils.cli import validate_context
 from clarifai.utils.constants import (
     DEFAULT_LOCAL_RUNNER_APP_ID,
@@ -473,9 +474,16 @@ def local_runner(ctx, model_path, pool_size):
     user_id = ctx.obj.current.user_id
     logger.info(f"Current user_id: {user_id}")
     if not user_id:
-        raise ValueError(
-            f"User with ID '{user_id}' not found. Use 'clarifai login' to setup context."
+        logger.error(f"User with ID '{user_id}' not found. Use 'clarifai login' to setup context.")
+        sys.exit(1)
+    pat = ctx.obj.current.pat
+    display_pat = pat_display(pat) if pat else ""
+    logger.info(f"Current PAT: {display_pat}")
+    if not pat:
+        logger.error(
+            "Personal Access Token (PAT) not found. Use 'clarifai login' to setup context."
         )
+        sys.exit(1)
     user = User(user_id=user_id, pat=ctx.obj.current.pat, base_url=ctx.obj.current.api_base)
     logger.debug("Checking if a local runner compute cluster exists...")
 

--- a/clarifai/utils/cli.py
+++ b/clarifai/utils/cli.py
@@ -221,4 +221,4 @@ def validate_context_auth(pat: str, user_id: str, api_base: str = None):
         else:
             logger.error(f"❌ Validation failed: \n{error_msg}")
             logger.error("Please check your credentials and try again.")
-        sys.exit(1)  # Exit without saving the configuration
+        raise click.Abort()  # Exit without saving the configuration

--- a/clarifai/utils/cli.py
+++ b/clarifai/utils/cli.py
@@ -209,9 +209,7 @@ def validate_context_auth(pat: str, user_id: str, api_base: str = None):
 
         # Check for common authentication errors and provide user-friendly messages
         if "PERMISSION_DENIED" in error_msg or "Unauthorized" in error_msg:
-            logger.error(
-                f"Invalid PAT token or insufficient permissions for user ID '{user_id}': {error_msg}"
-            )
+            logger.error(f"Invalid PAT token or incorrect user ID '{user_id}': {error_msg}")
         elif "UNAUTHENTICATED" in error_msg:
             logger.error(f"Invalid PAT token or user ID: {error_msg}")
         elif "SSL" in error_msg or "certificate" in error_msg:

--- a/clarifai/utils/cli.py
+++ b/clarifai/utils/cli.py
@@ -4,7 +4,7 @@ import pkgutil
 import sys
 import typing as t
 from collections import defaultdict
-from typing import OrderedDict, Tuple
+from typing import OrderedDict
 
 import click
 import yaml
@@ -176,7 +176,7 @@ def validate_context(ctx):
         sys.exit(1)
 
 
-def validate_context_auth(pat: str, user_id: str, api_base: str = None) -> Tuple[bool, str]:
+def validate_context_auth(pat: str, user_id: str, api_base: str = None):
     """
     Validate a Personal Access Token (PAT) by making a test API call.
 

--- a/clarifai/utils/cli.py
+++ b/clarifai/utils/cli.py
@@ -10,6 +10,8 @@ import click
 import yaml
 from tabulate import tabulate
 
+from clarifai.utils.logging import logger
+
 
 def from_yaml(filename: str):
     try:
@@ -174,7 +176,7 @@ def validate_context(ctx):
         sys.exit(1)
 
 
-def validate_pat_token(pat: str, user_id: str, api_base: str = None) -> Tuple[bool, str]:
+def validate_context_auth(pat: str, user_id: str, api_base: str = None) -> Tuple[bool, str]:
     """
     Validate a Personal Access Token (PAT) by making a test API call.
 
@@ -182,16 +184,13 @@ def validate_pat_token(pat: str, user_id: str, api_base: str = None) -> Tuple[bo
         pat (str): The Personal Access Token to validate
         user_id (str): The user ID associated with the token
         api_base (str): The API base URL. Defaults to None (uses default).
-
-    Returns:
-        tuple[bool, str]: A tuple of (is_valid, error_message)
-                         If valid: (True, "")
-                         If invalid: (False, error_description)
     """
     try:
         from clarifai_grpc.grpc.api.status import status_code_pb2
 
         from clarifai.client.user import User
+
+        logger.info("Validating the Context Credentials...")
 
         # Create user client for validation
         if api_base:
@@ -203,21 +202,23 @@ def validate_pat_token(pat: str, user_id: str, api_base: str = None) -> Tuple[bo
         response = user_client.get_user_info()
 
         if response.status.code == status_code_pb2.SUCCESS:
-            return True, ""
-        else:
-            return False, f"Authentication failed: {response.status.description}"
+            logger.info("✅ Context is valid")
 
     except Exception as e:
         error_msg = str(e)
 
         # Check for common authentication errors and provide user-friendly messages
         if "PERMISSION_DENIED" in error_msg or "Unauthorized" in error_msg:
-            return False, "Invalid PAT token or insufficient permissions"
+            logger.error(
+                f"Invalid PAT token or insufficient permissions for user ID '{user_id}': {error_msg}"
+            )
         elif "UNAUTHENTICATED" in error_msg:
-            return False, "Invalid PAT token"
+            logger.error(f"Invalid PAT token or user ID: {error_msg}")
         elif "SSL" in error_msg or "certificate" in error_msg:
-            return False, f"SSL/Certificate error: {error_msg}"
+            logger.error(f"SSL/Certificate error: {error_msg}")
         elif "Connection" in error_msg or "timeout" in error_msg:
-            return False, f"Network connection error: {error_msg}"
+            logger.error(f"Network connection error: {error_msg}")
         else:
-            return False, f"Validation error: {error_msg}"
+            logger.error(f"❌ Validation failed: \n{error_msg}")
+            logger.error("Please check your credentials and try again.")
+        sys.exit(1)  # Exit without saving the configuration


### PR DESCRIPTION
This pull request refactors the authentication and logging mechanisms in the Clarifai CLI to improve maintainability and user feedback. The key changes include replacing the `validate_pat_token` function with `validate_context_auth`, introducing structured logging via the `logger` module, and enhancing error handling and user feedback.

### Authentication Refactor:
* Replaced `validate_pat_token` with `validate_context_auth` for validating context credentials, consolidating the logic and improving clarity. (`clarifai/cli/base.py`, `clarifai/utils/cli.py`) [[1]](diffhunk://#diff-6b11868a510d65b7b8d2550d7a614cfad49fc8e5d709a9ef529343281c74edffL162-R162) [[2]](diffhunk://#diff-e3cafb4277139ff82e1f80b80b5dcc839f4420b365d79d97c44206e151e6eeb1L177-R194)
* Updated the `validate_context_auth` function to use structured logging for success and error messages, replacing return values with `sys.exit(1)` for invalid credentials. (`clarifai/utils/cli.py`)

### Logging Enhancements:
* Replaced `print` statements with `logger.info` and `logger.error` across the CLI commands to standardize logging and improve debugging. (`clarifai/cli/base.py`, `clarifai/cli/model.py`) [[1]](diffhunk://#diff-6b11868a510d65b7b8d2550d7a614cfad49fc8e5d709a9ef529343281c74edffL197-R188) [[2]](diffhunk://#diff-6b11868a510d65b7b8d2550d7a614cfad49fc8e5d709a9ef529343281c74edffL228-R222) [[3]](diffhunk://#diff-6b11868a510d65b7b8d2550d7a614cfad49fc8e5d709a9ef529343281c74edffL245-R242) [[4]](diffhunk://#diff-87a0ccd1cdbf7bbe707ef7b0de9923fd510a6e9342671fc56306193799808040L476-R486)
* Added `logger` import to relevant files for consistent logging usage. (`clarifai/utils/cli.py`)

### Error Handling Improvements:
* Enhanced error messages for invalid user IDs and missing PATs in the `local_runner` function, ensuring clear user guidance and proper exits. (`clarifai/cli/model.py`)
* Improved error feedback in `validate_context_auth` for common issues like invalid tokens, SSL errors, and network problems. (`clarifai/utils/cli.py`)