### PR TITLE
Added Playground URL to Local-Runner Logs

### DIFF
--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -875,7 +875,12 @@ def local_runner(ctx, model_path, pool_size):
     logger.info(f"""\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # About to start up the local runner in this terminal...
 # Here is a code snippet to call this model once it start from another terminal:{snippet}
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 """)
+
+    logger.info(
+        f"Playground: To chat with your model, visit:\n{ctx.obj.current.ui}/playground?model={model.id}__{version.id}&user_id={user_id}&app_id={app_id}"
+    )
 
     logger.info("Now starting the local runner...")
 


### PR DESCRIPTION
This pull request adds a new log message to the `local_runner` function in `clarifai/cli/model.py` to provide a direct link to the model's playground for easier interaction. 

Enhancements to logging:

* [`clarifai/cli/model.py`](diffhunk://#diff-87a0ccd1cdbf7bbe707ef7b0de9923fd510a6e9342671fc56306193799808040R878-R884): Added a log message with a URL to the model's playground, allowing users to chat with their model via a web interface. The URL includes parameters for the model ID, version ID, user ID, and app ID.