### PR TITLE
Increase the run-tests timeout from 20 to 30 mins to avoid PR builds timeout

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Increase the run-tests timeout from 20 to 30 mins to avoid PR builds timeout

### Why?
To avoid PR builds timing out

### Test?
This PR build succeeds