### PR TITLE
pipeline_steps should be used in templates

### DIFF
--- a/clarifai/cli/templates/pipeline_templates.py
+++ b/clarifai/cli/templates/pipeline_templates.py
@@ -25,12 +25,12 @@ def get_pipeline_config_template():
           steps:
           - - name: step-a
               templateRef:
-                name: users/your_user_id/apps/your_app_id/pipeline-steps/stepA  # TODO: please fill in
-                template: users/your_user_id/apps/your_app_id/pipeline-steps/stepA  # TODO: please fill in
+                name: users/your_user_id/apps/your_app_id/pipeline_steps/stepA  # TODO: please fill in
+                template: users/your_user_id/apps/your_app_id/pipeline_steps/stepA  # TODO: please fill in
           - - name: step-b
               templateRef:
-                name: users/your_user_id/apps/your_app_id/pipeline-steps/stepB  # TODO: please fill in
-                template: users/your_user_id/apps/your_app_id/pipeline-steps/stepB  # TODO: please fill in
+                name: users/your_user_id/apps/your_app_id/pipeline_steps/stepB  # TODO: please fill in
+                template: users/your_user_id/apps/your_app_id/pipeline_steps/stepB  # TODO: please fill in
 """
 
 

--- a/clarifai/runners/pipelines/pipeline_builder.py
+++ b/clarifai/runners/pipelines/pipeline_builder.py
@@ -86,7 +86,7 @@ class PipelineBuilder:
 
         if not step_directories:
             logger.info("No pipeline steps to upload (step_directories is empty)")
-            return True
+            return False  # treat this as an error.
 
         logger.info(f"Uploading {len(step_directories)} pipeline steps...")
 
@@ -191,25 +191,38 @@ class PipelineBuilder:
                         if "templateRef" in step:
                             template_ref = step["templateRef"]
                             name = template_ref["name"]
+                            # Extract step name
+                            parts = name.split('/')
 
                             # Check if this is a templateRef without version that we uploaded
                             if self.validator.TEMPLATE_REF_WITHOUT_VERSION_PATTERN.match(name):
-                                # Extract step name
-                                parts = name.split('/')
                                 step_name = parts[-1]
+                                # The step name should match the directory name or be derivable from it
+                                version_id = self.uploaded_step_versions.get(step_name, None)
+                                if version_id is not None:
+                                    # Update the templateRef to include version
+                                    new_name = f"{name}/versions/{version_id}"
+                                    template_ref["name"] = new_name
+                                    template_ref["template"] = new_name
+                                    logger.info(f"Updated templateRef from {name} to {new_name}")
+                            elif self.validator.TEMPLATE_REF_WITH_VERSION_PATTERN.match(name):
+                                # strip the /vestions/{version_id} from the end of name
+                                # to get the name like above
+                                orig_name = name
+                                name = orig_name.rsplit('/versions/', 1)[0]
+                                step_name = parts[-3]  # Get the step name from the path
 
-                                # Find the corresponding directory and version
-                                for step_dir, version_id in self.uploaded_step_versions.items():
-                                    # The step name should match the directory name or be derivable from it
-                                    if step_name == step_dir:
-                                        # Update the templateRef to include version
-                                        new_name = f"{name}/versions/{version_id}"
-                                        template_ref["name"] = new_name
-                                        template_ref["template"] = new_name
-                                        logger.info(
-                                            f"Updated templateRef from {name} to {new_name}"
-                                        )
-                                        break
+                                # if it already has a version, make sure it matches the uploaded
+                                # version
+                                version_id = self.uploaded_step_versions.get(step_name, None)
+                                if version_id is not None:
+                                    # Update the templateRef to include version
+                                    new_name = f"{name}/versions/{version_id}"
+                                    template_ref["name"] = new_name
+                                    template_ref["template"] = new_name
+                                    logger.info(
+                                        f"Updated templateRef from {orig_name} to {new_name}"
+                                    )
 
     def create_pipeline(self) -> bool:
         """Create the pipeline using PostPipelines RPC."""

--- a/clarifai/runners/utils/pipeline_validation.py
+++ b/clarifai/runners/utils/pipeline_validation.py
@@ -11,10 +11,10 @@ class PipelineConfigValidator:
 
     # Regex patterns for templateRef validation
     TEMPLATE_REF_WITH_VERSION_PATTERN = re.compile(
-        r'^users/([^/]+)/apps/([^/]+)/pipeline-steps/([^/]+)/versions/([^/]+)$'
+        r'^users/([^/]+)/apps/([^/]+)/pipeline_steps/([^/]+)/versions/([^/]+)$'
     )
     TEMPLATE_REF_WITHOUT_VERSION_PATTERN = re.compile(
-        r'^users/([^/]+)/apps/([^/]+)/pipeline-steps/([^/]+)$'
+        r'^users/([^/]+)/apps/([^/]+)/pipeline_steps/([^/]+)$'
     )
 
     @classmethod
@@ -120,8 +120,8 @@ class PipelineConfigValidator:
         ):
             raise ValueError(
                 f"templateRef name '{name}' must match either pattern:\n"
-                f"  - users/{{user_id}}/apps/{{app_id}}/pipeline-steps/{{step_id}}\n"
-                f"  - users/{{user_id}}/apps/{{app_id}}/pipeline-steps/{{step_id}}/versions/{{version_id}}"
+                f"  - users/{{user_id}}/apps/{{app_id}}/pipeline_steps/{{step_id}}\n"
+                f"  - users/{{user_id}}/apps/{{app_id}}/pipeline_steps/{{step_id}}/versions/{{version_id}}"
             )
 
     @classmethod

--- a/tests/cli/test_pipeline.py
+++ b/tests/cli/test_pipeline.py
@@ -82,12 +82,12 @@ spec:
     steps:
     - - name: step1
         templateRef:
-          name: users/test-user/apps/test-app/pipeline-steps/stepA
-          template: users/test-user/apps/test-app/pipeline-steps/stepA
+          name: users/test-user/apps/test-app/pipeline_steps/stepA
+          template: users/test-user/apps/test-app/pipeline_steps/stepA
     - - name: step2
         templateRef:
-          name: users/test-user/apps/test-app/pipeline-steps/stepB/versions/123
-          template: users/test-user/apps/test-app/pipeline-steps/stepB/versions/123
+          name: users/test-user/apps/test-app/pipeline_steps/stepB/versions/123
+          template: users/test-user/apps/test-app/pipeline_steps/stepB/versions/123
                     """
                 },
             }
@@ -113,8 +113,8 @@ spec:
     steps:
     - - name: step1
         templateRef:
-          name: users/test-user/apps/test-app/pipeline-steps/stepA
-          template: users/test-user/apps/test-app/pipeline-steps/stepB
+          name: users/test-user/apps/test-app/pipeline_steps/stepA
+          template: users/test-user/apps/test-app/pipeline_steps/stepB
                     """
                 },
             }
@@ -167,12 +167,12 @@ spec:
     steps:
     - - name: step1
         templateRef:
-          name: users/test-user/apps/test-app/pipeline-steps/stepA
-          template: users/test-user/apps/test-app/pipeline-steps/stepA
+          name: users/test-user/apps/test-app/pipeline_steps/stepA
+          template: users/test-user/apps/test-app/pipeline_steps/stepA
     - - name: step2
         templateRef:
-          name: users/test-user/apps/test-app/pipeline-steps/stepB/versions/123
-          template: users/test-user/apps/test-app/pipeline-steps/stepB/versions/123
+          name: users/test-user/apps/test-app/pipeline_steps/stepB/versions/123
+          template: users/test-user/apps/test-app/pipeline_steps/stepB/versions/123
                     """
                 },
             }
@@ -207,8 +207,8 @@ spec:
     steps:
     - - name: step1
         templateRef:
-          name: users/test-user/apps/test-app/pipeline-steps/stepA
-          template: users/test-user/apps/test-app/pipeline-steps/stepA
+          name: users/test-user/apps/test-app/pipeline_steps/stepA
+          template: users/test-user/apps/test-app/pipeline_steps/stepA
                     """
                 },
             }
@@ -327,7 +327,7 @@ spec:
 
         # Check that templateRef was updated
         template_ref = argo_spec["spec"]["templates"][0]["steps"][0][0]["templateRef"]
-        expected_name = "users/test-user/apps/test-app/pipeline-steps/stepA/versions/version-123"
+        expected_name = "users/test-user/apps/test-app/pipeline_steps/stepA/versions/version-123"
         assert template_ref["name"] == expected_name
         assert template_ref["template"] == expected_name
 
@@ -538,7 +538,7 @@ spec:
     steps:
     - - name: step1
         templateRef:
-          name: users/test-user/apps/test-app/pipeline-steps/stepA
+          name: users/test-user/apps/test-app/pipeline_steps/stepA
                     """
                 },
             }
@@ -566,8 +566,8 @@ spec:
     steps:
     - - name: step1
         templateRef:
-          name: users/test-user/apps/test-app/pipeline-steps/stepA/versions/123
-          template: users/test-user/apps/test-app/pipeline-steps/stepA/versions/123
+          name: users/test-user/apps/test-app/pipeline_steps/stepA/versions/123
+          template: users/test-user/apps/test-app/pipeline_steps/stepA/versions/123
                     """
                 },
             }
@@ -601,8 +601,8 @@ spec:
     steps:
     - - name: step1
         templateRef:
-          name: users/test-user/apps/test-app/pipeline-steps/stepA/versions/123
-          template: users/test-user/apps/test-app/pipeline-steps/stepA/versions/123
+          name: users/test-user/apps/test-app/pipeline_steps/stepA/versions/123
+          template: users/test-user/apps/test-app/pipeline_steps/stepA/versions/123
                     """
                 },
             }


### PR DESCRIPTION
We should be consistent with our API in using pipeline_steps not pipeline-steps in the templates. 

This make upload require some steps to upload for now so avoid confusion until lock is implemented. 

This updates the version IDs for existing template that have versions to make sure the config.yaml is always the final one uploaded. This caused a hard to understand bug about step name not being defined from the API when it had an old version ID in the config.yaml (which I guess was also in the uploaded API representation from pl upload).

Also improved logging by using proto to dict.