### PR TITLE
[TP-1816]: skip code generation when context is None

### DIFF
--- a/clarifai/runners/server.py
+++ b/clarifai/runners/server.py
@@ -143,7 +143,7 @@ def serve(
 
             snippet = code_script.generate_client_script(
                 method_signatures,
-                user_id=context.user_id if context else user_id,
+                user_id=context.user_id,
                 app_id=context.app_id,
                 model_id=context.model_id,
                 deployment_id=context.deployment_id,

--- a/clarifai/runners/server.py
+++ b/clarifai/runners/server.py
@@ -134,28 +134,34 @@ def serve(
             pat=pat,
             num_parallel_polls=num_threads,
         )
-        method_signatures = builder.get_method_signatures(mocking=False)
-        from clarifai.runners.utils import code_script
 
-        snippet = code_script.generate_client_script(
-            method_signatures,
-            user_id=context.user_id,
-            app_id=context.app_id,
-            model_id=context.model_id,
-            deployment_id=context.deployment_id,
-            base_url=context.api_base,
-        )
-        logger.info("✅ Your model is running locally and is ready for requests from the API...\n")
-        logger.info(
-            f"> Code Snippet: To call your model via the API, use this code snippet:\n{snippet}"
-        )
-        logger.info(
-            f"> Playground:   To chat with your model, visit: {context.ui}/playground?model={context.model_id}__{context.model_version_id}&user_id={context.user_id}&app_id={context.app_id}\n"
-        )
-        logger.info(
-            f"> API URL:      To call your model via the API, use this model URL: {context.ui}/users/{context.user_id}/apps/{context.app_id}/models/{context.model_id}\n"
-        )
-        logger.info("Press CTRL+C to stop the runner.\n")
+        if context is None:
+            logger.debug("Context is None. Skipping code snippet generation.")
+            method_signatures = builder.get_method_signatures(mocking=False)
+            from clarifai.runners.utils import code_script
+
+            snippet = code_script.generate_client_script(
+                method_signatures,
+                user_id=context.user_id if context else user_id,
+                app_id=context.app_id,
+                model_id=context.model_id,
+                deployment_id=context.deployment_id,
+                base_url=context.api_base,
+            )
+            logger.info(
+                "✅ Your model is running locally and is ready for requests from the API...\n"
+            )
+            logger.info(
+                f"> Code Snippet: To call your model via the API, use this code snippet:\n{snippet}"
+            )
+            logger.info(
+                f"> Playground:   To chat with your model, visit: {context.ui}/playground?model={context.model_id}__{context.model_version_id}&user_id={context.user_id}&app_id={context.app_id}\n"
+            )
+            logger.info(
+                f"> API URL:      To call your model via the API, use this model URL: {context.ui}/users/{context.user_id}/apps/{context.app_id}/models/{context.model_id}\n"
+            )
+            logger.info("Press CTRL+C to stop the runner.\n")
+
         runner.start()  # start the runner to fetch work from the API.
 
 

--- a/clarifai/runners/server.py
+++ b/clarifai/runners/server.py
@@ -137,6 +137,7 @@ def serve(
 
         if context is None:
             logger.debug("Context is None. Skipping code snippet generation.")
+        else:
             method_signatures = builder.get_method_signatures(mocking=False)
             from clarifai.runners.utils import code_script
 


### PR DESCRIPTION

### Why
<!-- Why is this PR trying to accomplish said thing? This is useful to understand your intention why this code should be merged to master. -->
* Context is None for model runners, so they crash on the code snippet generation that assumes context is not None.

### How
<!-- How is this PR trying to accomplish said thing? This is useful to understand the details of the code. The code reviewer will check this section to assist them with code review. -->
* Wrap the code generation in a condition on context not None.
