### PR TITLE
[PR-754] Fix ruff and dependencies-related issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,25 @@ git clone https://github.com/Clarifai/clarifai-python.git
 cd clarifai-python
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
-python setup.py install
+pip install -e .
 ```
 
+#### Linting
+
+For developers, use the precommit hook `.pre-commit-config.yaml` to automate linting.
+
+```bash
+pip install -r requirements-dev.txt
+pre-commit install
+```
+
+Now every time you run `git commit` your code will be automatically linted and won't commit if it fails.
+
+You can also manually trigger linting using:
+
+```bash
+pre-commit run --all-files
+```
 
 
 ## :memo: Getting started

--- a/clarifai/runners/models/model_builder.py
+++ b/clarifai/runners/models/model_builder.py
@@ -701,41 +701,6 @@ class ModelBuilder:
             )
         return is_amd_gpu
 
-    def _lint_python_code(self):
-        """
-        Lint the python code in the model.py file using flake8.
-        This will help catch any simple bugs in the code before uploading it to the API.
-        """
-        if not shutil.which('ruff'):
-            raise Exception("ruff command not found, please install ruff to lint the python code")
-        # List all the python files in the /1/ folder recursively and lint them.
-        python_files = []
-        for root, _, files in os.walk(os.path.join(self.folder, '1')):
-            for file in files:
-                if file.endswith('.py'):
-                    python_files.append(os.path.join(root, file))
-        if not python_files:
-            logger.info("No Python files found to lint, skipping linting step.")
-        else:
-            logger.info(f"Setup: Linting Python files: {python_files}")
-        # Run ruff to lint the python code.
-        command = "ruff check --select=F"
-        result = subprocess.run(
-            f"{command} {' '.join(python_files)}",
-            shell=True,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-        if result.returncode != 0:
-            logger.error(f"Error linting Python code: {result.stderr}")
-            logger.error("Output: " + result.stdout)
-            logger.error(
-                f"Failed to lint the Python code, please check the code for errors using '{command}' so you don't have simple errors in your code prior to upload."
-            )
-        else:
-            logger.info("Setup: Python code linted successfully, no errors found.")
-
     def _normalize_dockerfile_content(self, content):
         """
         Normalize Dockerfile content for comparison by standardizing whitespace and indentation.
@@ -788,9 +753,6 @@ class ModelBuilder:
         # Before we bother even picking the right base image, let's use uv to validate
         # that the requirements.txt file is valid and compatible.
         self._validate_requirements(python_version)
-
-        # Make sure any python code will not have simple bugs by linting it first.
-        self._lint_python_code()
 
         # Parse the requirements.txt file to determine the base image
         dependencies = self._parse_requirements()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,4 @@ click>=8.1.7
 requests>=2.32.3
 aiohttp>=3.10.0
 uv==0.7.12
-ruff==0.11.4
 psutil==7.0.0

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,6 @@ version = _search_version.group(1)
 
 with open("requirements.txt", "r", encoding="utf-8") as fh:
     install_requires = fh.read().split('\n')
-    # remove ruff as it doesn't work with setup.py
-    install_requires = [req for req in install_requires if not req.startswith('ruff')]
 
 if install_requires and install_requires[-1] == '':
     # Remove the last empty line


### PR DESCRIPTION
## Pull Request Overview

This PR fixes some package installation issue related to ruff: Fix package installation and development setup issues

- `clarifai model upload` fails with "ruff command not found" because setup.py excludes ruff (line 17). This PR remove this skip line from setup.py and remove ruff dependencies. 
- Update documentation to replace deprecated `python setup.py` commands with modern `pip install -e .` equivalents
- Document `requirements-dev.txt` usage in README for development environment setup (otherwise, there is no mention/usage of requiremets-dev.txt at all)

