### PR TITLE
Fix Local Runner CLI command

### DIFF
--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -569,9 +569,7 @@ def local_runner(ctx, model_path, pool_size, verbose):
     """
     from clarifai.client.user import User
     from clarifai.runners.models.model_builder import ModelBuilder
-    from clarifai.runners.server import serve
-
-    builder = ModelBuilder(model_path, download_validation_only=True)
+    from clarifai.runners.server import ModelServer
 
     validate_context(ctx)
     builder = ModelBuilder(model_path, download_validation_only=True)
@@ -895,8 +893,8 @@ def local_runner(ctx, model_path, pool_size, verbose):
     logger.info("✅ Starting local runner...")
 
     # This reads the config.yaml from the model_path so we alter it above first.
-    serve(
-        model_path,
+    server = ModelServer(model_path)
+    server.serve(
         pool_size=pool_size,
         num_threads=pool_size,
         user_id=user_id,


### PR DESCRIPTION
This pull request refactors the local model runner logic in `clarifai/cli/model.py` to improve clarity and modularity. The main change is replacing the direct use of the `serve` function with the `ModelServer` class, allowing for better encapsulation of server-related logic.

**Refactoring model serving logic:**

* Replaced the import of the `serve` function from `clarifai.runners.server` with an import of the `ModelServer` class, and updated the runner to instantiate a `ModelServer` object instead of calling the `serve` function directly.
* Updated the code to create a `ModelServer` instance and invoke its `serve` method, rather than calling the standalone `serve` function, for starting the local runner.