### PR TITLE
[EAGLE-6656]: Use latest local-dev model version for local runner

### DIFF
--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -755,12 +755,12 @@ def local_runner(ctx, model_path, pool_size, verbose):
     local_dev_versions = []
     for v in model_versions:
         config = v.model_version.pretrained_model_config
-        if config and "local_dev" in config and config["local_dev"].bool_value:
+        if config and config.local_dev and config.local_dev.bool_value:
             local_dev_versions.append(v)
             continue
 
         import_info = v.model_version.import_info
-        if import_info and "local_dev" in import_info and import_info["local_dev"].bool_value:
+        if import_info and import_info.local_dev and import_info.local_dev.bool_value:
             local_dev_versions.append(v)
 
     if local_dev_versions:

--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -759,10 +759,6 @@ def local_runner(ctx, model_path, pool_size, verbose):
             local_dev_versions.append(v)
             continue
 
-        import_info = v.model_version.import_info
-        if import_info and import_info.local_dev and import_info.local_dev.bool_value:
-            local_dev_versions.append(v)
-
     if local_dev_versions:
         # Use the latest version with local_dev=True. The list_versions() returns versions in descending order of creation.
         version = local_dev_versions[0].model_version

--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -755,12 +755,12 @@ def local_runner(ctx, model_path, pool_size, verbose):
     local_dev_versions = []
     for v in model_versions:
         config = v.model_version.pretrained_model_config
-        if config and config.get("local_dev") and config["local_dev"].bool_value:
+        if config and "local_dev" in config and config["local_dev"].bool_value:
             local_dev_versions.append(v)
             continue
 
         import_info = v.model_version.import_info
-        if import_info and import_info.get("local_dev") and import_info["local_dev"].bool_value:
+        if import_info and "local_dev" in import_info and import_info["local_dev"].bool_value:
             local_dev_versions.append(v)
 
     if local_dev_versions:


### PR DESCRIPTION
The `clarifai model local-runner` command has been updated to filter model versions based on the `local_dev` flag.

The command now selects the latest version where `local_dev` is set to `True` in either `pretrained_model_config` or `import_info`.

If no such version exists, a new version is created with the `local_dev` flag set to `True`.