### PR TITLE
[EAGLE-6656]:  Use latest local-dev model version in local runner

### DIFF
--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -759,9 +759,8 @@ def local_runner(ctx, model_path, pool_size, verbose):
     else:
         # Try to patch the latest version, and fallback to creating a new one if that fails.
         latest_version = model_versions[0]
-        logger.warning(
-            f"Attempting to patch latest version: {latest_version.model_version.id}"
-        )
+        logger.warning(f"Attempting to patch latest version: {latest_version.model_version.id}")
+
         try:
             patched_model = model.patch_version(
                 version_id=latest_version.model_version.id,
@@ -776,7 +775,7 @@ def local_runner(ctx, model_path, pool_size, verbose):
         except Exception as e:
             logger.warning(f"Failed to patch model version: {e}. Creating a new version instead.")
             create_new_version = True
-    
+
     if create_new_version:
         version = model.create_version(
             pretrained_model_config={"local_dev": True}, method_signatures=method_signatures

--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -752,25 +752,8 @@ def local_runner(ctx, model_path, pool_size, verbose):
     model_versions = list(model.list_versions())
     method_signatures = builder.get_method_signatures(mocking=False)
 
-    local_dev_versions = []
-    for v in model_versions:
-        config = v.model_version.pretrained_model_config
-        if config and config.local_dev:
-            local_dev_versions.append(v)
-            continue
-
-        import_info = v.model_version.import_info
-        if import_info and import_info.local_dev:
-            local_dev_versions.append(v)
-
-    if local_dev_versions:
-        # Use the latest version with local_dev=True.
-        version = local_dev_versions[0].model_version
-        logger.info(f"Using existing local-dev model version: {version.id}")
-        ctx.obj.current.CLARIFAI_MODEL_VERSION_ID = version.id
-        ctx.obj.to_yaml()
-    elif model_versions:
-        # If no local_dev versions, try to patch the latest version.
+    if model_versions:
+        # Try to patch the latest version, and fallback to creating a new one if that fails.
         latest_version = model_versions[0]
         logger.warning(
             f"No model version with local_dev=True found. Attempting to patch latest version: {latest_version.model_version.id}"

--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -749,24 +749,58 @@ def local_runner(ctx, model_path, pool_size, verbose):
 
     # Now we need to create a version for the model if no version exists. Only need one version that
     # mentions it's a local runner.
-    model_versions = [v for v in model.list_versions()]
+    model_versions = list(model.list_versions())
     method_signatures = builder.get_method_signatures(mocking=False)
-    if len(model_versions) == 0:
+
+    local_dev_versions = []
+    for v in model_versions:
+        config = v.model_version.pretrained_model_config
+        if config and config.local_dev:
+            local_dev_versions.append(v)
+            continue
+
+        import_info = v.model_version.import_info
+        if import_info and import_info.local_dev:
+            local_dev_versions.append(v)
+
+    if local_dev_versions:
+        # Use the latest version with local_dev=True.
+        version = local_dev_versions[0].model_version
+        logger.info(f"Using existing local-dev model version: {version.id}")
+        ctx.obj.current.CLARIFAI_MODEL_VERSION_ID = version.id
+        ctx.obj.to_yaml()
+    elif model_versions:
+        # If no local_dev versions, try to patch the latest version.
+        latest_version = model_versions[0]
+        logger.warning(
+            f"No model version with local_dev=True found. Attempting to patch latest version: {latest_version.model_version.id}"
+        )
+        try:
+            patched_model = model.patch_version(
+                version_id=latest_version.model_version.id,
+                pretrained_model_config={"local_dev": True},
+                method_signatures=method_signatures,
+            )
+            patched_model.load_info()
+            version = patched_model.model_version
+            logger.info(f"Successfully patched version {version.id}")
+            ctx.obj.current.CLARIFAI_MODEL_VERSION_ID = version.id
+            ctx.obj.to_yaml()  # save to yaml file.
+        except Exception as e:
+            logger.warning(f"Failed to patch model version: {e}. Creating a new version instead.")
+            version = model.create_version(
+                pretrained_model_config={"local_dev": True}, method_signatures=method_signatures
+            ).model_version
+            ctx.obj.current.CLARIFAI_MODEL_VERSION_ID = version.id
+            ctx.obj.to_yaml()
+    else:
+        # If no versions exist, create a new one.
         logger.warning("No model versions found. Creating a new version for local runner.")
         version = model.create_version(
             pretrained_model_config={"local_dev": True}, method_signatures=method_signatures
         ).model_version
         ctx.obj.current.CLARIFAI_MODEL_VERSION_ID = version.id
         ctx.obj.to_yaml()
-    else:
-        model.patch_version(
-            version_id=model_versions[0].model_version.id,
-            pretrained_model_config={"local_dev": True},
-            method_signatures=method_signatures,
-        )
-        version = model_versions[0].model_version
-        ctx.obj.current.CLARIFAI_MODEL_VERSION_ID = version.id
-        ctx.obj.to_yaml()  # save to yaml file.
 
     logger.info(f"Current model version {version.id}")
 


### PR DESCRIPTION
The `clarifai model local-runner` command attempts to patch the latest existing version. If patching fails, or if no versions exist at all, a new version is created with the `local_dev` flag set to `True`.
