### PR TITLE
Loosen requirement constraints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ fsspec>=2024.6.1
 click>=8.1.7
 requests>=2.32.3
 aiohttp>=3.10.0
-uv==0.7.12
-ruff==0.11.4
-psutil==7.0.0
-pydantic_core==2.33.2
-packaging==25.0
+uv>=0.7.12
+ruff>=0.11.4
+psutil>=7.0.0
+pydantic_core>=2.33.2
+packaging>=25.0


### PR DESCRIPTION
Resolves #769 

I've kept the `schema==0.7.5` constraint for now, as [the changelog for 10.3.3 says it was pinned due to breaking changes](https://github.com/Clarifai/clarifai-python/blob/d1e9eb41b26d04d65f19a78dbde8480673bf5099/CHANGELOG.md#1033---pypi---2024-05-07).