### PR TITLE
change log text

### DIFF
--- a/clarifai/runners/models/model_runner.py
+++ b/clarifai/runners/models/model_runner.py
@@ -132,8 +132,8 @@ class ModelRunner(BaseRunner):
         start_time = time.time()
         req_id = get_req_id_from_context()
         status_str = STATUS_UNKNOWN
-        # Endpoint is always POST /v2/.../outputs for this runner
-        endpoint = "POST /v2/.../outputs         "
+        # Operation name for logging purposes
+        endpoint = "model_predict"
 
         # if method_name == '_GET_SIGNATURES' then the request is for getting signatures and we don't want to log it.
         # This is a workaround to avoid logging the _GET_SIGNATURES method call.
@@ -204,7 +204,7 @@ class ModelRunner(BaseRunner):
         start_time = time.time()
         req_id = get_req_id_from_context()
         status_str = STATUS_UNKNOWN
-        endpoint = "POST /v2/.../outputs/generate"
+        endpoint = "model_generate"
 
         # Use req_secrets_context to temporarily set request-type secrets as environment variables
         with req_secrets_context(request):
@@ -260,7 +260,7 @@ class ModelRunner(BaseRunner):
         start_time = time.time()
         req_id = get_req_id_from_context()
         status_str = STATUS_UNKNOWN
-        endpoint = "POST /v2/.../outputs/stream  "
+        endpoint = "model_stream"
 
         # Get the first request to establish secrets context
         first_request = None


### PR DESCRIPTION
# Improve model runner endpoint logging clarity

## Summary
Replace confusing "POST /v2/.../outputs" endpoint strings in model runner logging with clearer operation names.

## Problem
The current logging uses misleading HTTP method patterns like `"POST /v2/.../outputs"` which confuses readers into thinking these are actual HTTP requests when they're internal model runner operations.

## Changes
- `"POST /v2/.../outputs"` → `"model_predict"`
- `"POST /v2/.../outputs/generate"` → `"model_generate"`  
- `"POST /v2/.../outputs/stream"` → `"model_stream"`

## Benefits
- **Clearer intent**: Log messages now clearly indicate what operation is being performed
- **Less confusion**: No more misleading HTTP method references
- **Consistent formatting**: Removes inconsistent spacing in endpoint strings
- **Better readability**: Logs now show clear operation names instead of confusing pseudo-HTTP patterns

## Before/After
**Before:**
```
POST /v2/.../outputs | SUCCESS | 245.67ms | req_id=abc123
POST /v2/.../outputs/generate | SUCCESS | 1234.56ms | req_id=def456
POST /v2/.../outputs/stream | ERROR | 567.89ms | req_id=ghi789
```

**After:**
```
model_predict | SUCCESS | 245.67ms | req_id=abc123
model_generate | SUCCESS | 1234.56ms | req_id=def456
model_stream | ERROR | 567.89ms | req_id=ghi789
```

This makes it immediately clear that these are internal model runner operations, not HTTP requests.

## Files Changed
- `clarifai/runners/models/model_runner.py` - Updated logging endpoint strings in three methods:
  - `runner_item_predict()` (line ~136)
  - `runner_item_generate()` (line ~207) 
  - `runner_item_stream()` (line ~263)