### PR TITLE
fixed async_client initialisation

### DIFF
--- a/clarifai/client/model.py
+++ b/clarifai/client/model.py
@@ -524,7 +524,6 @@ class Model(Lister, BaseClient):
                 runner_selector=self._runner_selector,
             )
             # Pass in None for async stub will create it.
-            print("######## inside client property created stub########", self.STUB)
             self._client = ModelClient(
                 stub=self.STUB, async_stub=None, request_template=request_template
             )
@@ -541,7 +540,6 @@ class Model(Lister, BaseClient):
                 model=self.model_info,
                 runner_selector=self._runner_selector,
             )
-            print("#######created async stub########", self.async_stub)
             # Create async client with async stub
             self._async_client = ModelClient(
                 stub=self.STUB, async_stub=self.async_stub, request_template=request_template


### PR DESCRIPTION
### Asynchronous Client Update

* Added an `async_client` property to the `Model` class, which initializes and returns a `ModelClient` instance configured with an async stub. This allows separation between synchronous and asynchronous client operations.
* Updated asynchronous methods (`async_predict`, `async_generate`, `async_stream`) to use `self.async_client` instead of `self.client`, ensuring proper usage of async stubs for async operations. [[1]](diffhunk://#diff-72537618efb580528c4abf05a6ae1418c34cc2ecce6ee68446bf087d730fe81fL577-R606) [[2]](diffhunk://#diff-72537618efb580528c4abf05a6ae1418c34cc2ecce6ee68446bf087d730fe81fL842-R869) [[3]](diffhunk://#diff-72537618efb580528c4abf05a6ae1418c34cc2ecce6ee68446bf087d730fe81fL1051-R1078)

* Modified the `__getattr__` method to delegate calls to async methods (those starting with `async_`) to the `async_client`, while other methods continue to use the regular `client`. This ensures method calls are routed to the appropriate client instance.

* Added the `_async_client` attribute to the class initialization to store the async client instance, mirroring the existing `_client` attribute for synchronous operations.<!---
The PR description should include WHAT, WHY, HOW it does things and how this PR is tested.
-->

<!-- ### What -->
<!--
You should try to state the WHAT in PR title only.
Your PR title should describe in short WHAT this PR does, e.g. "[AA-1] Add new Clarifai cool feature".
Uncomment the `### What` section above, if you decide to add more details about WHAT this PR does.
For example, you may choose to describe the WHAT in more detail in the below cases.
* If the PR title is too short to include what your PR does;
* If your PR does more than one thing, the title may not have enough space to include everything. In this case, consider creating multiple PRs to separate work and make it easier for everybody to understand. Alternatively, mention a list of things what this PR does in this section.
-->


