### PR TITLE
[PR-985] Fixed local-runner to handle duplicate runner id errors and to enable toolkit logs by default

### DIFF
--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -642,12 +642,12 @@ def run_locally(model_path, port, mode, keep_env, keep_image, skip_dockerfile=Fa
     help="The number of threads to use. On community plan, the compute time allocation is drained at a rate proportional to the number of threads.",
 )  # pylint: disable=range-builtin-not-iterating
 @click.option(
-    '--verbose',
+    '--suppress-toolkit-logs',
     is_flag=True,
     help='Show detailed logs including Ollama server output. By default, Ollama logs are suppressed.',
 )
 @click.pass_context
-def local_runner(ctx, model_path, pool_size, verbose):
+def local_runner(ctx, model_path, pool_size, suppress_toolkit_logs):
     """Run the model as a local runner to help debug your model connected to the API or to
     leverage local compute resources manually. This relies on many variables being present in the env
     of the currently selected context. If they are not present then default values will be used to
@@ -926,16 +926,28 @@ def local_runner(ctx, model_path, pool_size, verbose):
         logger.info(
             f"Creating the local runner tying this '{user_id}/{app_id}/models/{model.id}' model (version: {version.id}) to the '{user_id}/{compute_cluster_id}/{nodepool_id}' nodepool."
         )
-        runner = nodepool.create_runner(
-            runner_config={
-                "runner": {
-                    "description": "local runner for model testing",
-                    "worker": worker,
-                    "num_replicas": 1,
+        try:
+            logger.info("Checking for existing runners in the nodepool...")
+            runners = nodepool.list_runners(
+                model_version_ids=[version.id],
+            )
+            for runner in runners:
+                logger.info(
+                    f"Found existing runner {runner.id} for model version {version.id}. Reusing it."
+                )
+                runner_id = runner.id
+        except len(runner) == 0:
+            logger.warning("Failed to get existing runners in nodepool...Creating a new one.\n")
+            runner = nodepool.create_runner(
+                runner_config={
+                    "runner": {
+                        "description": "local runner for model testing",
+                        "worker": worker,
+                        "num_replicas": 1,
+                    }
                 }
-            }
-        )
-        runner_id = runner.id
+            )
+            runner_id = runner.id
         ctx.obj.current.CLARIFAI_RUNNER_ID = runner.id
         ctx.obj.to_yaml()
 
@@ -1025,7 +1037,7 @@ def local_runner(ctx, model_path, pool_size, verbose):
             customize_ollama_model(
                 model_path=model_path,
                 user_id=user_id,
-                verbose=True if verbose else False,
+                verbose=False if suppress_toolkit_logs else True,
             )
         except Exception as e:
             logger.error(f"Failed to customize Ollama model: {e}")


### PR DESCRIPTION

<!---
The PR description should include WHAT, WHY, HOW it does things and how this PR is tested.
-->

<!-- ### What -->
<!--
You should try to state the WHAT in PR title only.
Your PR title should describe in short WHAT this PR does, e.g. "[AA-1] Add new Clarifai cool feature".
Uncomment the `### What` section above, if you decide to add more details about WHAT this PR does.
For example, you may choose to describe the WHAT in more detail in the below cases.
* If the PR title is too short to include what your PR does;
* If your PR does more than one thing, the title may not have enough space to include everything. In this case, consider creating multiple PRs to separate work and make it easier for everybody to understand. Alternatively, mention a list of things what this PR does in this section.
-->



### Why
<!-- Why is this PR trying to accomplish said thing? This is useful to understand your intention why this code should be merged to master. -->
* https://clarifai.atlassian.net/browse/PR-985

* Currently when a user does fresh clarifai login and creates context, it doesn't fill in the runner-id, so when running the local-runner models with existing runner-ids in DB, it runs into DATABASE DUPLICATE ERROR. Since runner-id is unique UUID, it creates unique id for each model versions. 

* Suppressing toolkits logs by default is not a good experience, when an user wants to see how the model loading is happening.

### How
<!-- How is this PR trying to accomplish said thing? This is useful to understand the details of the code. The code reviewer will check this section to assist them with code review. -->
**Runner management improvements:**

* Added a new `list_runners` method to the `Nodepool` class in `clarifai/client/nodepool.py`, allowing retrieval of existing runners for a given model version. This supports more efficient runner reuse and reduces redundant runner creation.
* Updated the `local_runner` logic in `clarifai/cli/model.py` to check for and reuse existing runners in the nodepool before creating a new one, improving resource utilization.

**Logging and CLI option changes:**

* Replaced the `--verbose` CLI option with `--suppress-toolkit-logs` in the local runner command, making log control more intuitive and updating the corresponding logic to invert the verbose flag. [[1]](diffhunk://#diff-87a0ccd1cdbf7bbe707ef7b0de9923fd510a6e9342671fc56306193799808040L645-R650) [[2]](diffhunk://#diff-87a0ccd1cdbf7bbe707ef7b0de9923fd510a6e9342671fc56306193799808040L1028-R1040)

### Tests
<!-- How is this PR tested? Write some tests to convince yourself and the reviewer that your code works. Sometimes, no tests are necessary, but we should always ask the question "Can I add some tests for this PR?". -->
* Tested locally.

### Notes
<!-- Add any additional notes here. -->
*
