### PR TITLE
[PR-726]: Added CLARIFAI_HF_TOKEN to CLI Context

### DIFF
--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -407,6 +407,7 @@ def _ensure_hf_token(ctx, model_path):
     Ensure HF_TOKEN is present in CLI context.
     """
     import yaml
+
     try:
         config_path = os.path.join(model_path, "config.yaml")
         if os.path.isfile(config_path):
@@ -577,7 +578,9 @@ def signatures(model_path, out_path):
     help='Flag to skip generating a dockerfile so that you can manually edit an already created dockerfile. If not provided, intelligently handle existing Dockerfiles with user confirmation.',
 )
 @click.pass_context
-def test_locally(ctx, model_path, keep_env=False, keep_image=False, mode='env', skip_dockerfile=False):
+def test_locally(
+    ctx, model_path, keep_env=False, keep_image=False, mode='env', skip_dockerfile=False
+):
     """Test model locally.
 
     MODEL_PATH: Path to the model directory. If not specified, the current directory is used by default.


### PR DESCRIPTION
This pull request introduces improvements to the handling and propagation of the Hugging Face token (`HF_TOKEN`) in the CLI workflows for model management. The main change is the addition of a new helper function to ensure the token is consistently available in the CLI context, and its integration into several key commands to streamline authentication and configuration.

**Token management improvements:**

* Added a new `_ensure_hf_token` function in `clarifai/cli/model.py` to ensure the Hugging Face token is present in the CLI context, loading it from the environment or `config.yaml` if necessary, and updating the context accordingly.

* Updated the following CLI commands to call `_ensure_hf_token` and ensure the token is set before proceeding:
  - `upload`
  - `download_checkpoints` (now also uses `@click.pass_context`)
  - `test_locally` (now also uses `@click.pass_context`)
  - `run_locally` (now also uses `@click.pass_context`)
  - `local_runner`