### PR TITLE
[PR-1037] prevent auto-generated cache file

### DIFF
--- a/clarifai/runners/models/model_builder.py
+++ b/clarifai/runners/models/model_builder.py
@@ -259,6 +259,8 @@ class ModelBuilder:
         sys.modules[module_name] = module
 
         original_import = builtins.__import__
+        # Prevent __pycache__ folder generation during module execution
+        original_dont_write_bytecode = sys.dont_write_bytecode
 
         def custom_import(name, globals=None, locals=None, fromlist=(), level=0):
             # Allow standard libraries and clarifai
@@ -273,13 +275,16 @@ class ModelBuilder:
             builtins.__import__ = custom_import
 
         try:
+            # Set sys.dont_write_bytecode to prevent __pycache__ folder generation
+            sys.dont_write_bytecode = True
             spec.loader.exec_module(module)
         except Exception as e:
             logger.error(f"Error loading model.py: {e}")
             raise
         finally:
-            # Restore the original __import__ function
+            # Restore the original __import__ function and bytecode setting
             builtins.__import__ = original_import
+            sys.dont_write_bytecode = original_dont_write_bytecode
 
         # Find all classes in the model.py file that are subclasses of ModelClass
         classes = [
@@ -1035,7 +1040,8 @@ class ModelBuilder:
         else:
             logger.info(f"Setup: Linting Python files: {python_files}")
         # Run ruff to lint the python code.
-        command = "ruff check --select=F"
+        # Use --no-cache to prevent .ruff_cache folder generation in model directories
+        command = "ruff check --select=F --no-cache"
         result = subprocess.run(
             f"{command} {' '.join(python_files)}",
             shell=True,
@@ -1576,7 +1582,7 @@ class ModelBuilder:
 
         def filter_func(tarinfo):
             name = tarinfo.name
-            exclude = [self.tar_file, "*~", "*.pyc", "*.pyo", "__pycache__"]
+            exclude = [self.tar_file, "*~", "*.pyc", "*.pyo", "__pycache__", ".ruff_cache"]
             if when != "upload":
                 exclude.append(self.checkpoint_suffix)
             return None if any(name.endswith(ex) for ex in exclude) else tarinfo

--- a/clarifai/runners/models/model_run_locally.py
+++ b/clarifai/runners/models/model_run_locally.py
@@ -140,7 +140,9 @@ class ModelRunLocally:
         process = None
         try:
             logger.info("Testing the model locally...")
-            process = subprocess.Popen(command)
+            # Set PYTHONDONTWRITEBYTECODE=1 to prevent __pycache__ folder generation
+            env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+            process = subprocess.Popen(command, env=env)
             # Wait for the process to complete
             process.wait()
             if process.returncode == 0:
@@ -183,7 +185,9 @@ class ModelRunLocally:
             logger.info(
                 f"Starting model server at localhost:{port} with the model at {self.model_path}..."
             )
-            subprocess.check_call(command)
+            # Set PYTHONDONTWRITEBYTECODE=1 to prevent __pycache__ folder generation
+            env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+            subprocess.check_call(command, env=env)
             logger.info("Model server started successfully and running at localhost:{port}")
         except subprocess.CalledProcessError as e:
             logger.error(f"Error running model server: {e}")
@@ -370,6 +374,8 @@ class ModelRunLocally:
             if env_vars:
                 for key, value in env_vars.items():
                     cmd.extend(["-e", f"{key}={value}"])
+            # Set PYTHONDONTWRITEBYTECODE=1 to prevent __pycache__ folder generation
+            cmd.extend(["-e", "PYTHONDONTWRITEBYTECODE=1"])
             # Add the image name
             cmd.append(image_name)
             # update the CMD to run the server
@@ -420,6 +426,8 @@ class ModelRunLocally:
             if env_vars:
                 for key, value in env_vars.items():
                     cmd.extend(["-e", f"{key}={value}"])
+            # Set PYTHONDONTWRITEBYTECODE=1 to prevent __pycache__ folder generation
+            cmd.extend(["-e", "PYTHONDONTWRITEBYTECODE=1"])
             # Add the image name
             cmd.append(image_name)
             # update the CMD to test the model inside the container

--- a/clarifai/runners/pipeline_steps/pipeline_step_builder.py
+++ b/clarifai/runners/pipeline_steps/pipeline_step_builder.py
@@ -255,7 +255,14 @@ COPY --link=true requirements.txt config.yaml /home/nonroot/main/
 
         def filter_func(tarinfo):
             name = tarinfo.name
-            exclude = [os.path.basename(self.tar_file), "*~", "*.pyc", "*.pyo", "__pycache__"]
+            exclude = [
+                os.path.basename(self.tar_file),
+                "*~",
+                "*.pyc",
+                "*.pyo",
+                "__pycache__",
+                ".ruff_cache",
+            ]
             return None if any(name.endswith(ex) for ex in exclude) else tarinfo
 
         with tarfile.open(file_path, "w:gz") as tar:


### PR DESCRIPTION
This PR aims to prevent auto-generated cache directories (`.ruff_cache` and `__pycache__`) from being created during model operations and exclude them from uploaded archives.


### Key Changes
- Added `PYTHONDONTWRITEBYTECODE=1` environment variable to subprocess calls and Docker containers to prevent `__pycache__` generation
- Added `sys.dont_write_bytecode = True` setting when loading model modules to prevent bytecode compilation
- Added `--no-cache` flag to ruff linting command to prevent `.ruff_cache` directory creation
- Added `.ruff_cache` to tar file exclusion lists for model and pipeline step uploads
