### PR TITLE
Update pydantic_core>=2.33.2 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ uv==0.7.12
 ruff==0.11.4
 psutil==7.0.0
 pygments>=2.19.2
-pydantic_core==2.33.2
+pydantic_core>=2.33.2
 packaging==25.0


### PR DESCRIPTION
Currently latest vLLM is having conflicts with `pydantic_core `
```
0.146 Using Python 3.11.13 environment at: /venv                                                                                                                                              
1.128   × No solution found when resolving dependencies:                                                                                                                                      
1.128   ╰─▶ Because only the following versions of pydantic are available:                                                                                                                    
1.128           pydantic<=2.12.0                                                                                                                                                              
1.128           pydantic==2.12.1
1.128           pydantic==2.12.2
1.128           pydantic==2.12.3
1.128           pydantic==2.12.4
1.128           pydantic==2.12.5
1.128       and pydantic>=2.12.4 depends on pydantic-core==2.41.5, we can conclude
1.128       that pydantic>2.12.3 depends on pydantic-core==2.41.5.
1.128       And because pydantic>=2.12.2,<=2.12.3 depends on pydantic-core==2.41.4,
1.128       we can conclude that pydantic>2.12.1 depends on pydantic-core>=2.41.4.
1.128       And because pydantic==2.12.1 was yanked (reason: references a
1.128       yanked version of pydantic-core) and pydantic==2.12.0 depends on
1.128       pydantic-core==2.41.1, we can conclude that pydantic>=2.12.0 depends on
1.128       one of:
1.128           pydantic-core==2.41.1
1.128           pydantic-core>=2.41.4
1.128 
1.128       And because anthropic==0.71.0 depends on pydantic>=1.9.0 and
1.128       vllm==0.11.2 depends on pydantic>=2.12.0, we can conclude that
1.128       anthropic==0.71.0, all of:
1.128           pydantic-core<2.41.1
1.128           pydantic-core>2.41.1,<2.41.4
1.128       , vllm==0.11.2 are incompatible.
1.128       And because vllm==0.11.2 depends on anthropic==0.71.0 and
1.128       clarifai==11.10.3 depends on pydantic-core==2.33.2, we can conclude that
1.128       clarifai==11.10.3 and vllm==0.11.2 are incompatible.
1.128       And because you require clarifai==11.10.3 and vllm==0.11.2, we can
1.128       conclude that your requirements are unsatisfiable.
```