### PR TITLE
Fix TypeError when accelerator_type is None in config.yaml

### DIFF
--- a/clarifai/runners/models/model_builder.py
+++ b/clarifai/runners/models/model_builder.py
@@ -1006,11 +1006,13 @@ class ModelBuilder:
         if "inference_compute_info" in self.config:
             inference_compute_info = self.config.get('inference_compute_info')
             if 'accelerator_type' in inference_compute_info:
-                for accelerator in inference_compute_info['accelerator_type']:
-                    if 'amd' in accelerator.lower():
-                        is_amd_gpu = True
-                    elif 'nvidia' in accelerator.lower():
-                        is_nvidia_gpu = True
+                accelerator_type = inference_compute_info['accelerator_type']
+                if accelerator_type:  # Check if not None or empty
+                    for accelerator in accelerator_type:
+                        if 'amd' in accelerator.lower():
+                            is_amd_gpu = True
+                        elif 'nvidia' in accelerator.lower():
+                            is_nvidia_gpu = True
         if is_amd_gpu and is_nvidia_gpu:
             raise Exception(
                 "Both AMD and NVIDIA GPUs are specified in the config file, please use only one type of GPU."


### PR DESCRIPTION
## Root Cause
The `_is_amd()` method checks if the `accelerator_type` key exists but doesn't validate that its value is not `None` before attempting to iterate over it.

## Solution
Added a null/empty check before iterating over `accelerator_type`:
- Check if `accelerator_type` value is not `None` or empty
- Only iterate if the value is a valid list/iterable
- Gracefully handles cases where `accelerator_type` is explicitly set to `null`

## Testing
- Verified fix handles `accelerator_type: null` correctly
- No errors when field is missing or empty
- Normal GPU detection still works when valid values are provided

## Impact
- **Users affected**: Anyone uploading CPU-only models or models with `accelerator_type: null` in config.yaml
- **Severity**: High - Command was completely broken for this use case
- **Risk**: Low - Minimal change with proper null checking

Fixes the model upload workflow for CPU-only models.