### PR TITLE
Add support for concept IDs from config.yaml in visual detector/classifier

### DIFF
--- a/clarifai/runners/models/visual_classifier_class.py
+++ b/clarifai/runners/models/visual_classifier_class.py
@@ -1,10 +1,11 @@
 import os
 import tempfile
 from io import BytesIO
-from typing import Dict, Iterator, List
+from typing import Dict, Iterator, List, Optional
 
 import cv2
 import torch
+import yaml
 from PIL import Image as PILImage
 
 from clarifai.runners.models.model_class import ModelClass
@@ -14,6 +15,52 @@ from clarifai.utils.logging import logger
 
 class VisualClassifierClass(ModelClass):
     """Base class for visual classification models supporting image and video processing."""
+
+    @staticmethod
+    def load_concepts_from_config(config_path: str) -> Optional[Dict[int, Dict[str, str]]]:
+        """Load concepts from config.yaml and return a mapping of index to concept info.
+
+        Args:
+            config_path: Path to the config.yaml file or the model directory containing it.
+
+        Returns:
+            Dictionary mapping label indices to concept info {'id': id, 'name': name},
+            or None if no concepts are found in the config.
+
+        Example:
+            >>> concepts_map = VisualClassifierClass.load_concepts_from_config('/path/to/model')
+            >>> # Returns: {0: {'id': '0', 'name': 'person'}, 1: {'id': '1', 'name': 'bicycle'}, ...}
+        """
+        # Handle both file path and directory path
+        if os.path.isdir(config_path):
+            config_file = os.path.join(config_path, 'config.yaml')
+        else:
+            config_file = config_path
+
+        if not os.path.exists(config_file):
+            logger.warning(f"Config file not found at {config_file}")
+            return None
+
+        try:
+            with open(config_file, 'r') as f:
+                config = yaml.safe_load(f)
+
+            concepts = config.get('concepts')
+            if not concepts:
+                return None
+
+            # Build mapping from index to concept info
+            concepts_map = {}
+            for idx, concept in enumerate(concepts):
+                concept_id = concept.get('id', str(idx))
+                concept_name = concept.get('name', concept_id)
+                concepts_map[idx] = {'id': concept_id, 'name': concept_name}
+
+            logger.info(f"Loaded {len(concepts_map)} concepts from config")
+            return concepts_map
+        except Exception as e:
+            logger.warning(f"Failed to load concepts from config: {e}")
+            return None
 
     @staticmethod
     def preprocess_image(image_bytes: bytes) -> PILImage:
@@ -52,13 +99,18 @@ class VisualClassifierClass(ModelClass):
 
     @staticmethod
     def process_concepts(
-        logits: torch.Tensor, model_labels: Dict[int, str]
+        logits: torch.Tensor,
+        model_labels: Dict[int, str],
+        concepts_map: Optional[Dict[int, Dict[str, str]]] = None,
     ) -> List[List[Concept]]:
         """Convert model logits into a structured format of concepts.
 
         Args:
             logits: Model output logits as a tensor (batch_size x num_classes)
-            model_labels: Dictionary mapping label indices to label names
+            model_labels: Dictionary mapping label indices to label names (from model config)
+            concepts_map: Optional dictionary mapping label indices to concept info
+                {'id': id, 'name': name} from config.yaml. When provided, concept IDs
+                will be taken from this map. Use load_concepts_from_config() to create this.
 
         Returns:
             List of lists containing Concept objects for each input in the batch
@@ -69,7 +121,17 @@ class VisualClassifierClass(ModelClass):
             sorted_indices = torch.argsort(probs, dim=-1, descending=True)
             output_concepts = []
             for idx in sorted_indices:
-                concept = Concept(name=model_labels[idx.item()], value=probs[idx].item())
+                label_idx = idx.item()
+                # Use concepts_map if available, otherwise fall back to model_labels
+                if concepts_map and label_idx in concepts_map:
+                    concept_info = concepts_map[label_idx]
+                    concept = Concept(
+                        id=concept_info['id'],
+                        name=concept_info['name'],
+                        value=probs[idx].item(),
+                    )
+                else:
+                    concept = Concept(name=model_labels[label_idx], value=probs[idx].item())
                 output_concepts.append(concept)
             outputs.append(output_concepts)
         return outputs

--- a/clarifai/runners/models/visual_detector_class.py
+++ b/clarifai/runners/models/visual_detector_class.py
@@ -1,10 +1,11 @@
 import os
 import tempfile
 from io import BytesIO
-from typing import Dict, Iterator, List
+from typing import Dict, Iterator, List, Optional
 
 import cv2
 import torch
+import yaml
 from PIL import Image as PILImage
 
 from clarifai.runners.models.model_class import ModelClass
@@ -14,6 +15,52 @@ from clarifai.utils.logging import logger
 
 class VisualDetectorClass(ModelClass):
     """Base class for visual detection models supporting image and video processing."""
+
+    @staticmethod
+    def load_concepts_from_config(config_path: str) -> Optional[Dict[int, Dict[str, str]]]:
+        """Load concepts from config.yaml and return a mapping of index to concept info.
+
+        Args:
+            config_path: Path to the config.yaml file or the model directory containing it.
+
+        Returns:
+            Dictionary mapping label indices to concept info {'id': id, 'name': name},
+            or None if no concepts are found in the config.
+
+        Example:
+            >>> concepts_map = VisualDetectorClass.load_concepts_from_config('/path/to/model')
+            >>> # Returns: {0: {'id': '0', 'name': 'person'}, 1: {'id': '1', 'name': 'bicycle'}, ...}
+        """
+        # Handle both file path and directory path
+        if os.path.isdir(config_path):
+            config_file = os.path.join(config_path, 'config.yaml')
+        else:
+            config_file = config_path
+
+        if not os.path.exists(config_file):
+            logger.warning(f"Config file not found at {config_file}")
+            return None
+
+        try:
+            with open(config_file, 'r') as f:
+                config = yaml.safe_load(f)
+
+            concepts = config.get('concepts')
+            if not concepts:
+                return None
+
+            # Build mapping from index to concept info
+            concepts_map = {}
+            for idx, concept in enumerate(concepts):
+                concept_id = concept.get('id', str(idx))
+                concept_name = concept.get('name', concept_id)
+                concepts_map[idx] = {'id': concept_id, 'name': concept_name}
+
+            logger.info(f"Loaded {len(concepts_map)} concepts from config")
+            return concepts_map
+        except Exception as e:
+            logger.warning(f"Failed to load concepts from config: {e}")
+            return None
 
     @staticmethod
     def preprocess_image(image_bytes: bytes) -> PILImage:
@@ -52,14 +99,20 @@ class VisualDetectorClass(ModelClass):
 
     @staticmethod
     def process_detections(
-        results: List[Dict[str, torch.Tensor]], threshold: float, model_labels: Dict[int, str]
+        results: List[Dict[str, torch.Tensor]],
+        threshold: float,
+        model_labels: Dict[int, str],
+        concepts_map: Optional[Dict[int, Dict[str, str]]] = None,
     ) -> List[List[Region]]:
         """Convert model outputs into a structured format of detections.
 
         Args:
             results: Raw detection results from model
             threshold: Confidence threshold for detections
-            model_labels: Dictionary mapping label indices to names
+            model_labels: Dictionary mapping label indices to names (from model config)
+            concepts_map: Optional dictionary mapping label indices to concept info
+                {'id': id, 'name': name} from config.yaml. When provided, concept IDs
+                will be taken from this map. Use load_concepts_from_config() to create this.
 
         Returns:
             List of lists containing Region objects for each detection
@@ -69,11 +122,18 @@ class VisualDetectorClass(ModelClass):
             detections = []
             for score, label_idx, box in zip(result["scores"], result["labels"], result["boxes"]):
                 if score > threshold:
-                    label = model_labels[label_idx.item()]
-                    detections.append(
-                        Region(
-                            box=box.tolist(), concepts=[Concept(name=label, value=score.item())]
+                    idx = label_idx.item()
+                    # Use concepts_map if available, otherwise fall back to model_labels
+                    if concepts_map and idx in concepts_map:
+                        concept_info = concepts_map[idx]
+                        concept = Concept(
+                            id=concept_info['id'],
+                            name=concept_info['name'],
+                            value=score.item(),
                         )
-                    )
+                    else:
+                        label = model_labels[idx]
+                        concept = Concept(name=label, value=score.item())
+                    detections.append(Region(box=box.tolist(), concepts=[concept]))
             outputs.append(detections)
         return outputs


### PR DESCRIPTION
Description:

  Problem

  When using visual detector/classifier models, the concept IDs in prediction output don't match what's
  configured in config.yaml and stored in the model's output_info:

  - config.yaml / output_info in DB: id='0', name='person'
  - Actual prediction output: id='person', name='person'

  This breaks downstream tasks like filtering and thresholding for auto-annotation that rely on consistent
  concept IDs.

  Root Cause

  process_detections() and process_concepts() only passed name to the Concept() constructor, so the ID was
  auto-generated from the name instead of using the ID specified in config.yaml.

  Solution

  Added to VisualDetectorClass and VisualClassifierClass:

  1. load_concepts_from_config(config_path) - loads concepts from config.yaml and returns a mapping {index:
   {'id': id, 'name': name}}
  2. Optional concepts_map parameter to process_detections() / process_concepts() - when provided, uses
  concept IDs from config.yaml

  Usage

  model_path = os.path.dirname(os.path.dirname(__file__))
  concepts_map = VisualDetectorClass.load_concepts_from_config(model_path)
  outputs = VisualDetectorClass.process_detections(results, threshold, model_labels, concepts_map)

  Backward Compatibility

  Fully backward compatible - existing models work without modification. Models that want config.yaml
  concept IDs can opt-in by loading and passing concepts_map.