### PR TITLE
[PR-1228] Relax clarifai-protocol version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 clarifai-grpc>=12.0.6
-clarifai-protocol==0.0.35
+clarifai-protocol>=0.0.35,<0.1.0
 numpy>=1.22.0
 tqdm>=4.65.0
 PyYAML>=6.0.1


### PR DESCRIPTION
## Summary
Relaxes `clarifai-protocol` version constraint from `==0.0.35` to `>=0.0.35,<0.1.0` to allow patch version updates while maintaining compatibility.

## Motivation
The strict pin (`==0.0.35`) was overly restrictive and prevented automatic updates to bug fixes and improvements in the 0.0.x series.

## Changes
- Updated `requirements.txt`: `clarifai-protocol==0.0.35` → `clarifai-protocol>=0.0.35,<0.1.0`

## Testing
✅ All runner tests pass with `clarifai-protocol==0.0.49` (latest version)
- `tests/runners/test_runners.py`
- `tests/runners/test_runners_proto.py`
- `tests/cli/test_local_runner_cli.py`

## API Compatibility Analysis
Reviewed changes between versions 0.0.35 → 0.0.49 (14 versions):
- ✅ **No breaking changes to public API** (`BaseRunner`, `get_item_id`, `register_item_abort_callback`, `shutdown_abort_executor`)
- All changes are internal improvements:
  - Auto-annotation task enhancements
  - Multiprocessing spawn support for CUDA compatibility
  - Health probe improvements and race condition fixes
  - Control connection fixes
  - Performance optimizations

## Benefits
- Automatically receive bug fixes and improvements in the 0.0.x series
- Maintains backward compatibility (constrained to <0.1.0)
- Aligns with semantic versioning expectations for pre-1.0 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)