### PR TITLE
fix: prevent _ensure_hf_token from swallowing click.Abort

### DIFF
--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -884,6 +884,8 @@ def _ensure_hf_token(ctx, model_path):
             if 'checkpoints' not in config:
                 config['checkpoints'] = {}
             config["checkpoints"]["hf_token"] = hf_token
+    except click.Abort:
+        raise
     except Exception as e:
         logger.warning(f"Unexpected error ensuring HF_TOKEN: {e}")
 


### PR DESCRIPTION
## Quick Fix Summary

- Fix `_ensure_hf_token` swallowing `click.Abort` due to a broad `except Exception` handler, which was producing a misleading empty warning (`Unexpected error ensuring HF_TOKEN:`) and allowing execution to continue past an intentional abort

## Root Cause

When `config.yaml` is missing, `_ensure_hf_token` correctly raises `click.Abort()`. But the outer `except Exception` catches it, downgrades it to a cryptic warning, and lets execution fall through to `ModelBuilder._validate_folder` which then crashes with a noisy `AssertionError` traceback.

## Fix

Add `except click.Abort: raise` before the general `except Exception` so the abort propagates as intended.

Closes #936

## Test plan

- [x] `tests/cli/test_local_runner_cli.py` — all 7 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)