### PR TITLE
PR-1234 Add openai as a core dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ pydantic_core>=2.33.2
 packaging>=25.0
 tenacity>=8.2.3
 httpx>=0.27.0
+openai>=1.0.0


### PR DESCRIPTION
## Summary
- Adds `openai>=1.0.0` to `requirements.txt` so it is installed automatically with `pip install clarifai`

## Test plan
- [ ] Verify `pip install clarifai` pulls in the `openai` package
- [ ] Verify existing functionality is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)