### PR TITLE
Fix dependency constraint to prevent upgrade issues in existing envir…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-clarifai-grpc>=12.0.6
+clarifai-grpc>=12.1.0
 clarifai-protocol>=0.0.35,<0.1.0
 numpy>=1.22.0
 tqdm>=4.65.0


### PR DESCRIPTION
## Changes:
- clarifai-grpc: >=12.0.6 -> >=12.1.0
  Fixes: AttributeError: Protocol message ModelVersion has no "num_threads" field

## Problem
When upgrading `clarifai` from 12.1.6 to 12.1.7 in existing environments
`clarifai model upload` fails with AttributeError: Protocol message ModelVersion has no "num_threads" field.
**Root Cause:**  
Version 12.1.7 introduced code that accesses `num_threads` field on ModelVersion protobuf, but this field only exists in `clarifai-grpc >= 12.1.0`. The loose constraint `clarifai-grpc>=12.0.6` allows pip to skip upgrading from 12.0.10, leaving incompatible versions.
