### PR TITLE
Fix regression in serializer

### DIFF
--- a/clarifai/runners/utils/serializers.py
+++ b/clarifai/runners/utils/serializers.py
@@ -21,7 +21,20 @@ class Serializer:
 
 def is_repeated_field(field_name):
     descriptor = resources_pb2.Data.DESCRIPTOR.fields_by_name.get(field_name)
-    return descriptor and descriptor.is_repeated
+    return _descriptor_is_repeated(descriptor)
+
+
+def _descriptor_is_repeated(descriptor):
+    if descriptor is None:
+        return False
+
+    is_repeated = getattr(descriptor, 'is_repeated', None)
+    if is_repeated is not None:
+        return bool(is_repeated)
+
+    label = getattr(descriptor, 'label', None)
+    repeated_label = getattr(descriptor, 'LABEL_REPEATED', None)
+    return repeated_label is not None and label == repeated_label
 
 
 class AtomicFieldSerializer(Serializer):

--- a/clarifai/utils/protobuf.py
+++ b/clarifai/utils/protobuf.py
@@ -18,6 +18,13 @@ WRAPPER_TYPES = {
 }
 
 
+def _field_is_repeated(field_descriptor: FieldDescriptor) -> bool:
+    is_repeated = getattr(field_descriptor, 'is_repeated', None)
+    if is_repeated is not None:
+        return bool(is_repeated)
+    return field_descriptor.label == FieldDescriptor.LABEL_REPEATED
+
+
 def dict_to_protobuf(pb_obj: Message, data: dict) -> None:
     """Recursively convert a nested dictionary to a Protobuf message object.
 
@@ -37,7 +44,7 @@ def dict_to_protobuf(pb_obj: Message, data: dict) -> None:
 
         try:
             # Handle repeated fields (lists)
-            if field_descriptor.is_repeated:
+            if _field_is_repeated(field_descriptor):
                 _handle_repeated_field(pb_obj, field_descriptor, field, value)
 
             # Handle message fields (nested messages)


### PR DESCRIPTION
### What
Fixes regression in serializer

### Why
```
  File "/Users/nitinbhojwani/virtualenv/v1/lib/python3.10/site-packages/clarifai/client/app.py", line 15, in <module>
    from clarifai.client.model import Model
  File "/Users/nitinbhojwani/virtualenv/v1/lib/python3.10/site-packages/clarifai/client/model.py", line 23, in <module>
    from clarifai.client.model_client import ModelClient
  File "/Users/nitinbhojwani/virtualenv/v1/lib/python3.10/site-packages/clarifai/client/model_client.py", line 12, in <module>
    from clarifai.runners.utils import code_script, method_signatures
  File "/Users/nitinbhojwani/virtualenv/v1/lib/python3.10/site-packages/clarifai/runners/__init__.py", line 1, in <module>
    from .models.mcp_class import MCPModelClass
  File "/Users/nitinbhojwani/virtualenv/v1/lib/python3.10/site-packages/clarifai/runners/models/mcp_class.py", line 14, in <module>
    from clarifai.runners.models.model_class import ModelClass
  File "/Users/nitinbhojwani/virtualenv/v1/lib/python3.10/site-packages/clarifai/runners/models/model_class.py", line 16, in <module>
    from clarifai.runners.utils.method_signatures import (
  File "/Users/nitinbhojwani/virtualenv/v1/lib/python3.10/site-packages/clarifai/runners/utils/method_signatures.py", line 465, in <module>
    resources_pb2.ModelTypeField.DataType.TEXT, MessageSerializer('text', data_types.Text)
  File "/Users/nitinbhojwani/virtualenv/v1/lib/python3.10/site-packages/clarifai/runners/utils/serializers.py", line 45, in __init__
    self.is_repeated_field = is_repeated_field(field_name)
  File "/Users/nitinbhojwani/virtualenv/v1/lib/python3.10/site-packages/clarifai/runners/utils/serializers.py", line 24, in is_repeated_field
    return descriptor and descriptor.is_repeated
AttributeError: 'google._upb._message.FieldDescriptor' object has no attribute 'is_repeated'
```