### PR TITLE
Fix User.app() to return actual server data instead of empty values

### DIFF
--- a/clarifai/client/user.py
+++ b/clarifai/client/user.py
@@ -361,7 +361,10 @@ class User(Lister, BaseClient):
             raise Exception(response.status)
 
         kwargs['user_id'] = self.id
-        return App.from_auth_helper(auth=self.auth_helper, app_id=app_id, **kwargs)
+        kwargs['app_id'] = app_id
+        app = App.from_auth_helper(auth=self.auth_helper, **kwargs)
+        app.app_info.CopyFrom(response.app)
+        return app
 
     def runner(self, runner_id: str) -> dict:
         """Returns a Runner object if exists.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -173,6 +173,17 @@ class TestApp:
             )
             assert "SUCCESS" in caplog.text
 
+    def test_get_app(self, create_client):
+        # Verify that user.app() returns actual server data, not empty/default values
+        app = create_client.app(app_id=CREATE_APP_ID)
+        # These should match what was set in test_patch_app
+        assert app.app_info.visibility.gettable == 10, (
+            f"Expected visibility 10, got {app.app_info.visibility.gettable}"
+        )
+        assert app.app_info.description == 'App Patching Test', (
+            f"Expected description 'App Patching Test', got '{app.app_info.description}'"
+        )
+
     def test_patch_dataset(self, create_app, caplog):
         with caplog.at_level(logging.INFO):
             create_app.patch_dataset(


### PR DESCRIPTION
Bug: User.app() was fetching app data from server but ignoring response.app and returning an App with only app_id and default/empty values.

Fix: Use app.app_info.CopyFrom(response.app) to directly copy the protobuf from server, preserving all fields including enums (e.g., visibility=10).

Test: Added test_get_app() to verify visibility and description are correctly retrieved from server.
