### PR TITLE
Fix duplicate health server startup in ModelRunner

### DIFF
--- a/clarifai/runners/models/model_runner.py
+++ b/clarifai/runners/models/model_runner.py
@@ -90,7 +90,6 @@ class ModelRunner(BaseRunner):
         HealthProbeRequestHandler.is_ready = True
         HealthProbeRequestHandler.is_startup = True
 
-        start_health_server_thread(port=health_check_port, address='')
         if health_check_port is not None:
             start_health_server_thread(port=health_check_port, address='')
 


### PR DESCRIPTION
  ## Fix duplicate health server startup in ModelRunner

  start_health_server_thread() was called twice on model load — once
  unconditionally and once inside the
  guard. The first call would bind the port successfully, causing the
  second call to fail with OSError: [Errno 98] Address already in use.

  Remove the unconditional call, keeping only the guarded one which
  also correctly respects health_check_port=None to disable the server.

- Thread-2 (first call) bound port 8080 successfully and kept running — so health probes (/healthz/liveness, /healthz/readiness) still responded correctly
- Thread-3 (second call) crashed silently on startup and died