### PR TITLE
Fix admission control hasattr overhead in ModelRunner poll loop

### DIFF
--- a/clarifai/runners/models/model_runner.py
+++ b/clarifai/runners/models/model_runner.py
@@ -49,6 +49,11 @@ class ModelRunner(BaseRunner):
         )
         self.model = model
 
+        # Cache hasattr results for hot-path methods to avoid repeated attribute lookups
+        # on every poll loop iteration (called thousands of times per second across 128 threads).
+        self._model_has_check_admission = hasattr(model, 'check_admission')
+        self._model_has_admission_control_backoff = hasattr(model, 'admission_control_backoff')
+
         # Store authentication parameters for URL fetching
         self._user_id = user_id
         self._pat = pat
@@ -116,7 +121,7 @@ class ModelRunner(BaseRunner):
         """
         The time in seconds to wait before retrying admission control. If the model defines this backoff, we use that.
         """
-        if hasattr(self.model, 'admission_control_backoff'):
+        if self._model_has_admission_control_backoff:
             return self.model.admission_control_backoff
         return super().admission_control_backoff
 
@@ -127,10 +132,9 @@ class ModelRunner(BaseRunner):
         Returns:
           bool: True if the runner is ready to accept work, False otherwise.
         """
-        if hasattr(self.model, 'check_admission'):
+        if self._model_has_check_admission:
             return self.model.check_admission()
-        else:
-            return super().check_admission()
+        return super().check_admission()
 
     def runner_item_predict(
         self, runner_item: service_pb2.RunnerItem


### PR DESCRIPTION
`check_admission()` and `admission_control_backoff` are called on every iteration of the runner poll loop, which runs across 128 threads as fast as possible. Both methods used `hasattr(self.model, ...)` on each call — an attribute lookup that triggers Python's full
  descriptor protocol every time.

  This was introduced in 12.2.0 when admission control was added (#941) and caused a measurable **7-10% latency regression at low-to-mid concurrency** (c=1..20) compared to 12.1.6.

  ## Fix

  Resolve `hasattr()` once at `__init__` time and store the results as `_model_has_check_admission` and `_model_has_admission_control_backoff` boolean flags.

  ## Benchmark (AA dataset, via Clarifai API, speculative decoding on)

  | Concurrency | 12.1.6 (baseline) | 12.2.1 before fix | 12.2.1 after fix |
  |-------------|-------------------|-------------------|------------------|
  | 1           | 0.778s            | 0.743s            | 0.760s           |
  | 10          | 0.906s            | 0.928s            | 0.970s           |
  | 20          | 1.034s            | 1.097s            | **1.027s** ✓     |
  | 50          | 1.726s            | 1.661s            | **1.629s**       |
  | 100         | 3.174s            | 3.199s            | **3.093s**       |

  Latency at c=20 is fully recovered to 12.1.6 levels. High-concurrency (c=50, c=100) is the best yet across all runs.