### PR TITLE
Fix confusing error UX when model serve has missing deps

### DIFF
--- a/clarifai/utils/cli.py
+++ b/clarifai/utils/cli.py
@@ -595,7 +595,7 @@ def check_requirements_installed(model_path: str = None, dependencies: dict = No
         if not dependencies:
             dependencies = parse_requirements(model_path)
         missing = [
-            full_req
+            f"{package_name}{full_req}" if full_req else package_name
             for package_name, full_req in dependencies.items()
             if not _is_package_installed(package_name)
         ]
@@ -609,8 +609,15 @@ def check_requirements_installed(model_path: str = None, dependencies: dict = No
             f"❌ {len(missing)} of {len(dependencies)} required packages are missing in the current environment"
         )
         logger.error("\n".join(f"  - {pkg}" for pkg in missing))
-        requirements_path = Path(model_path) / "requirements.txt"
-        logger.warning(f"To install: pip install -r {requirements_path}")
+        if model_path:
+            try:
+                requirements_path = (Path(model_path) / "requirements.txt").relative_to(Path.cwd())
+            except ValueError:
+                requirements_path = Path(model_path) / "requirements.txt"
+            logger.warning(f"To install: pip install -r {requirements_path}")
+        logger.warning(
+            "Tip: use '--mode env' to auto-install deps in a virtualenv, or '--mode container' to run in Docker."
+        )
         return False
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- Fix `NoneType` crash in `check_requirements_installed` when `model_path` is `None` — was causing a traceback instead of a clean error message
- Show package names in missing deps list (was only showing version specifiers like `>=2.6.0`)
- Show relative path in `pip install -r` hint instead of absolute
- Replace `UserError` traceback with clean `click.Abort()` since error details are already logged
- Add tip about `--mode env` / `--mode container` alternatives
- Print playground/API URLs via `click.echo()` for cleaner terminal output

## Test plan
- [ ] Run `clarifai model serve .` in a directory with missing deps and verify clean error output (no traceback)
- [ ] Verify package names show in the missing deps list
- [ ] Verify `pip install -r` shows relative path
- [ ] Run `clarifai model serve .` with all deps installed and verify playground URL prints cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)