### PR TITLE
Block vLLM/SGLang serve on non-Linux with clear error

### DIFF
--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -1121,7 +1121,7 @@ def _run_local_grpc(model_path, mode, port, keep_image, verbose):
                 if engine in dependencies or toolkit_provider == engine:
                     raise UserError(
                         f"{engine} is not supported on {_platform.system()}. It requires a Linux environment with GPU access.\n"
-                        "  Use 'clarifai model deploy .' to run on cloud GPU, or switch to the Ollama toolkit for local serving."
+                        "  Use 'clarifai model deploy .' to run on cloud GPU, or switch to the Ollama or LM Studio toolkit for local serving."
                     )
 
         if "ollama" in dependencies or toolkit_provider == 'ollama':
@@ -1398,7 +1398,7 @@ def serve_cmd(ctx, model_path, grpc, mode, port, concurrency, keep_image, verbos
             if engine in dependencies or toolkit_provider == engine:
                 raise UserError(
                     f"{engine} is not supported on {_platform.system()}. It requires a Linux environment with GPU access.\n"
-                    "  Use 'clarifai model deploy .' to run on cloud GPU, or switch to the Ollama toolkit for local serving."
+                    "  Use 'clarifai model deploy .' to run on cloud GPU, or switch to the Ollama or LM Studio toolkit for local serving."
                 )
 
     if "ollama" in dependencies or toolkit_provider == 'ollama':


### PR DESCRIPTION
## Summary
- Add early platform check when serving models that use vLLM or SGLang toolkits
- On macOS/Windows, these engines crash deep in C extensions with opaque `AttributeError` tracebacks
- Now fails fast with a clear message: what's wrong and what to do instead (cloud deploy or Ollama)
- Applied to both serve paths (API-connected and `--grpc`)

## Test plan
- [ ] On macOS, run `clarifai model serve .` in a vLLM model directory — should get clear error instead of C extension traceback
- [ ] On macOS, run `clarifai model serve --grpc` in an SGLang model directory — same clear error
- [ ] On Linux, verify serve still works normally (platform check passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)