### PR TITLE
bypass user input override if there is ps version

### DIFF
--- a/clarifai/utils/template_manager.py
+++ b/clarifai/utils/template_manager.py
@@ -410,6 +410,7 @@ class TemplateManager:
                                         if (
                                             isinstance(current_value, str)
                                             and '/pipeline_steps/' in current_value
+                                            and '/versions/' not in current_value
                                         ):
                                             parts = current_value.split('/pipeline_steps/')
                                             if len(parts) == 2:


### PR DESCRIPTION
Add a quick fix in pipeline cli:

Before, it took user inputs and always override the templateRef
Now, for making it compatible with the training UI template, **will skip the `templateRef` override if there is `versions` in the value already**

This is only for CLI/SDK usability.