### PR TITLE
Fix model init creating subdirectory instead of updating existing model

### DIFF
--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -1489,11 +1489,17 @@ def _run_local_grpc(model_path, mode, port, keep_image, verbose):
                 raise UserError(
                     "Ollama is not installed. Install from https://ollama.com/ to use the Ollama toolkit."
                 )
+            toolkit_model = config.get('toolkit', {}).get('model')
+            if toolkit_model and not os.environ.get('OLLAMA_MODEL_NAME'):
+                os.environ['OLLAMA_MODEL_NAME'] = toolkit_model
         elif toolkit == 'lmstudio':
             if not check_lmstudio_installed():
                 raise UserError(
                     "LM Studio is not installed. Install from https://lmstudio.com/ to use the LM Studio toolkit."
                 )
+            toolkit_model = config.get('toolkit', {}).get('model')
+            if toolkit_model and not os.environ.get('LMS_MODEL_NAME'):
+                os.environ['LMS_MODEL_NAME'] = toolkit_model
 
     # Get method signatures to generate test snippet
     use_mocking = mode in ("container", "env")
@@ -1760,11 +1766,19 @@ def serve_cmd(ctx, model_path, grpc, mode, port, concurrency, keep_image, verbos
             raise UserError(
                 "Ollama is not installed. Install from https://ollama.com/ to use the Ollama toolkit."
             )
+        # Inject toolkit.model from config.yaml so model.py picks it up via OLLAMA_MODEL_NAME
+        toolkit_model = config.get('toolkit', {}).get('model')
+        if toolkit_model and not os.environ.get('OLLAMA_MODEL_NAME'):
+            os.environ['OLLAMA_MODEL_NAME'] = toolkit_model
     elif toolkit == 'lmstudio':
         if not check_lmstudio_installed():
             raise UserError(
                 "LM Studio is not installed. Install from https://lmstudio.com/ to use the LM Studio toolkit."
             )
+        # Inject toolkit.model from config.yaml so model.py picks it up via LMS_MODEL_NAME
+        toolkit_model = config.get('toolkit', {}).get('model')
+        if toolkit_model and not os.environ.get('LMS_MODEL_NAME'):
+            os.environ['LMS_MODEL_NAME'] = toolkit_model
 
     # Method signatures from ModelBuilder (same as upload/deploy).
     # Use mocking=False for "none" mode since requirements are verified installed.


### PR DESCRIPTION
## Summary
- **Fix init creating subdirectories on re-init**: When running `clarifai model init --toolkit X --model-name Y` inside an already-initialized model directory (without an explicit path), the command derived a new subdirectory from `--model-name` instead of updating the current directory's `config.yaml`. Now checks for an existing `config.yaml` first and defaults to `.` so re-init updates the model in place.
- **Fix serve ignoring config.yaml model name**: `clarifai model serve` ignored `toolkit.model` in `config.yaml` because the model name was hardcoded in `model.py` during init. Now the serve command injects `toolkit.model` from `config.yaml` into the environment (`OLLAMA_MODEL_NAME` / `LMS_MODEL_NAME`) so the model template picks it up at runtime. This means changing the model in `config.yaml` is respected by serve without needing to re-init.
- Both fixes apply to ollama and lmstudio toolkits, and to both `serve` and `serve --grpc` code paths.

## Test plan
- [ ] Run `clarifai model init --toolkit ollama --model-name model-a` in a fresh directory — should create `model-a/` as before
- [ ] `cd model-a/` then run `clarifai model init --toolkit ollama --model-name model-b` — should update `config.yaml` in place (not create a `model-b/` subdirectory)
- [ ] Edit `toolkit.model` in `config.yaml` to a different model, run `clarifai model serve` — should pull and serve the new model
- [ ] Verify `OLLAMA_MODEL_NAME` env var still takes priority over `config.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)