### PR TITLE
fix: use total_tokens - prompt_tokens to accurately report completion tokens

### DIFF
--- a/clarifai/runners/models/openai_class.py
+++ b/clarifai/runners/models/openai_class.py
@@ -159,13 +159,22 @@ class OpenAIModelClass(ModelClass):
                 prompt_tokens = getattr(resp.usage, "prompt_tokens", 0) or getattr(
                     resp.usage, "input_tokens", 0
                 )
-                completion_tokens = getattr(resp.usage, "completion_tokens", 0) or getattr(
-                    resp.usage, "output_tokens", 0
-                )
+                # Use total_tokens - prompt_tokens to capture reasoning/thinking tokens
+                total_tokens = getattr(resp.usage, "total_tokens", None)
+                if total_tokens:
+                    completion_tokens = total_tokens - prompt_tokens
+                else:
+                    completion_tokens = getattr(resp.usage, "completion_tokens", 0) or getattr(
+                        resp.usage, "output_tokens", 0
+                    )
             # stream responses.create
             else:
                 prompt_tokens = getattr(resp.response.usage, "input_tokens", 0)
-                completion_tokens = getattr(resp.response.usage, "output_tokens", 0)
+                total_tokens = getattr(resp.response.usage, "total_tokens", None)
+                if total_tokens:
+                    completion_tokens = total_tokens - prompt_tokens
+                else:
+                    completion_tokens = getattr(resp.response.usage, "output_tokens", 0)
             if prompt_tokens is None:
                 prompt_tokens = 0
             if completion_tokens is None:


### PR DESCRIPTION
## Problem

For models with reasoning/thinking tokens (Gemini, o1/o3), `completion_tokens`
only reflects visible output and excludes thinking tokens. This causes silent
under-reporting of actual token usage:

- Gemini: `prompt=20, completion=424, total=1016` → 572 thinking tokens dropped
- OpenAI o1/o3: `total_tokens > prompt_tokens + completion_tokens` due to reasoning tokens

## Fix

Use `total_tokens - prompt_tokens` as the reported completion count in `_set_usage`.
This captures all output tokens (visible + thinking/reasoning) regardless of model family.

Falls back to `completion_tokens`/`output_tokens` when `total_tokens` is unavailable,
preserving existing behavior for models that don't report it.

## Behavior by model

| Model | Before | After |
|---|---|---|
| Standard OpenAI | `completion_tokens` | `total - prompt` = same value ✓ |
| Gemini | under-reports (misses thinking tokens) | `total - prompt` = all output tokens ✓ |
| o1/o3 reasoning | under-reports (misses reasoning tokens) | `total - prompt` = all output tokens ✓ |
| `total_tokens` absent | `completion_tokens` | `completion_tokens` (fallback) ✓ |
