### PR TITLE
CLI Improvement - Fix user/app conflicts with context

### DIFF
--- a/clarifai/runners/models/model_builder.py
+++ b/clarifai/runners/models/model_builder.py
@@ -1576,13 +1576,20 @@ class ModelBuilder:
     def create_dockerfile(self, generate_dockerfile=False):
         """
         Create a Dockerfile for the model based on its configuration.
+
+        When generate_dockerfile=False (default), an existing Dockerfile is NEVER
+        overwritten — it is always preserved. A warning is printed if the existing
+        file differs from what would be auto-generated.
+
+        When generate_dockerfile=True, the Dockerfile is always (re)written.
         """
+        import click
+
         generated_content = self._generate_dockerfile_content()
 
         if generate_dockerfile:
             should_create_dockerfile = True
         else:
-            # Always handle Dockerfile creation with user interaction when content differs
             dockerfile_path = os.path.join(self.folder, 'Dockerfile')
             should_create_dockerfile = True
 
@@ -1598,15 +1605,14 @@ class ModelBuilder:
                     logger.info(
                         "Dockerfile already exists with identical content, skipping creation."
                     )
-                    should_create_dockerfile = False
                 else:
-                    logger.warning(
-                        "Dockerfile differs from what would be auto-generated from your current "
-                        "config.yaml. Keeping your existing Dockerfile. If your config has changed "
-                        "(e.g. streaming_video_consumer, build_info), delete the Dockerfile to "
-                        "regenerate it, or update it manually."
+                    click.echo(
+                        click.style("  Note: ", fg="yellow")
+                        + "Existing Dockerfile differs from auto-generated. "
+                        "Keeping yours. Delete it to regenerate."
                     )
-                    should_create_dockerfile = False
+                # Never overwrite an existing Dockerfile
+                should_create_dockerfile = False
 
         if should_create_dockerfile:
             # Write Dockerfile

--- a/clarifai/runners/models/model_deploy.py
+++ b/clarifai/runners/models/model_deploy.py
@@ -235,10 +235,28 @@ class ModelDeployer:
                 app_id=self.app_id,
             )
 
-        # Resolve IDs from the builder's config
+        # Resolve IDs from the builder's normalized config.
+        # The builder already applied the precedence: config.yaml > injected user_id/app_id.
+        # We must use the SAME values the builder uses for upload, so that deployment
+        # targets the same user/app. If config.yaml defines user_id/app_id, they win.
         model_config = self._builder.config.get('model', {})
-        self.user_id = self.user_id or model_config.get('user_id')
-        self.app_id = self.app_id or model_config.get('app_id')
+        resolved_user = model_config.get('user_id', self.user_id)
+        resolved_app = model_config.get('app_id', self.app_id)
+
+        # Warn if config.yaml overrides CLI context
+        if resolved_user and self.user_id and resolved_user != self.user_id:
+            out.warning(
+                f"config.yaml overrides CLI context: user_id='{resolved_user}' "
+                f"(context: '{self.user_id}')"
+            )
+        if resolved_app and self.app_id and resolved_app != self.app_id:
+            out.warning(
+                f"config.yaml overrides CLI context: app_id='{resolved_app}' "
+                f"(context: '{self.app_id}')"
+            )
+
+        self.user_id = resolved_user
+        self.app_id = resolved_app
         self.model_id = self._builder.model_id
 
         # Read compute section from config (instance, cloud, region)


### PR DESCRIPTION

Improves the model deployment CLI flow by ensuring deployments use the same resolved `user_id`/`app_id` as the model builder (avoiding context vs `config.yaml` mismatches), and refines Dockerfile generation messaging when an existing Dockerfile is present.