### PR TITLE
Auto-detect and clamp max_tokens to backend's max_seq_len

### DIFF
--- a/clarifai/runners/models/openai_class.py
+++ b/clarifai/runners/models/openai_class.py
@@ -39,17 +39,38 @@ class OpenAIModelClass(ModelClass):
     client = None
     model = None
 
+    # Max sequence length for clamping max_tokens. Auto-detected from the backend's
+    # /v1/models response (max_model_len field) when available. Can also be set explicitly
+    # as a class attribute to override auto-detection.
+    max_seq_len = None
+
     def __init__(self) -> None:
         super().__init__()
         if self.client is None:
             raise NotImplementedError("Subclasses must set the 'client' class attribute")
+        models_response = None
         if self.model is None:
             try:
-                self.model = self._retry_models_list().data[0].id
+                models_response = self._retry_models_list()
+                self.model = models_response.data[0].id
             except Exception as e:
                 raise NotImplementedError(
                     "Subclasses must set the 'model' class attribute or ensure the client can list models"
                 ) from e
+
+        # Auto-detect max_seq_len from backend if not explicitly set.
+        if self.max_seq_len is None:
+            try:
+                if models_response is None:
+                    models_response = self._retry_models_list()
+                for model_card in models_response.data:
+                    max_model_len = getattr(model_card, 'max_model_len', None)
+                    if max_model_len is not None:
+                        self.max_seq_len = max_model_len
+                        logger.info("Auto-detected max_seq_len=%d from backend", max_model_len)
+                        break
+            except Exception:
+                pass  # Not critical — clamping is best-effort
 
     @retry(
         stop=stop_after_attempt(3),
@@ -315,6 +336,17 @@ class OpenAIModelClass(ModelClass):
         elif max_tokens is not None:
             # Only max_tokens exists - copy to max_completion_tokens for newer backends
             request_data['max_completion_tokens'] = max_tokens
+
+        # Clamp to max_seq_len if configured, to avoid degraded throughput or backend errors.
+        if self.max_seq_len is not None:
+            for field in ('max_tokens', 'max_completion_tokens'):
+                if field in request_data and request_data[field] is not None:
+                    if request_data[field] > self.max_seq_len:
+                        logger.warning(
+                            "Clamping %s from %d to max_seq_len %d",
+                            field, request_data[field], self.max_seq_len,
+                        )
+                        request_data[field] = self.max_seq_len
         if 'top_p' in request_data:
             request_data['top_p'] = float(request_data['top_p'])
         if 'top_k' in request_data:

--- a/clarifai/runners/models/openai_class.py
+++ b/clarifai/runners/models/openai_class.py
@@ -344,7 +344,9 @@ class OpenAIModelClass(ModelClass):
                     if request_data[field] > self.max_seq_len:
                         logger.warning(
                             "Clamping %s from %d to max_seq_len %d",
-                            field, request_data[field], self.max_seq_len,
+                            field,
+                            request_data[field],
+                            self.max_seq_len,
                         )
                         request_data[field] = self.max_seq_len
         if 'top_p' in request_data:

--- a/clarifai/runners/models/openai_class.py
+++ b/clarifai/runners/models/openai_class.py
@@ -63,12 +63,38 @@ class OpenAIModelClass(ModelClass):
             try:
                 if models_response is None:
                     models_response = self._retry_models_list()
+
+                selected_max_len = None
+
+                # First, prefer the model card that matches self.model (if any).
                 for model_card in models_response.data:
-                    max_model_len = getattr(model_card, 'max_model_len', None)
-                    if max_model_len is not None:
-                        self.max_seq_len = max_model_len
-                        logger.info("Auto-detected max_seq_len=%d from backend", max_model_len)
+                    if getattr(model_card, "id", None) == self.model:
+                        max_model_len = getattr(model_card, "max_model_len", None)
+                        if max_model_len is not None:
+                            try:
+                                selected_max_len = int(max_model_len)
+                            except (TypeError, ValueError):
+                                selected_max_len = None
                         break
+
+                # Fallback: use the first model with a usable max_model_len.
+                if selected_max_len is None:
+                    for model_card in models_response.data:
+                        max_model_len = getattr(model_card, "max_model_len", None)
+                        if max_model_len is not None:
+                            try:
+                                selected_max_len = int(max_model_len)
+                                break
+                            except (TypeError, ValueError):
+                                continue
+
+                if isinstance(selected_max_len, int):
+                    self.max_seq_len = selected_max_len
+                    logger.info(
+                        "Auto-detected max_seq_len=%d from backend for model %s",
+                        self.max_seq_len,
+                        self.model,
+                    )
             except Exception:
                 pass  # Not critical — clamping is best-effort
 

--- a/tests/runners/test_openai_update_old_fields.py
+++ b/tests/runners/test_openai_update_old_fields.py
@@ -73,3 +73,70 @@ class TestUpdateOldFields:
         # Check that syncing happened
         assert result.get("max_tokens") == 100
         assert result.get("max_completion_tokens") == 100
+
+
+class TestUpdateOldFieldsMaxSeqLen:
+    """Tests for max_seq_len clamping in _update_old_fields."""
+
+    def setup_method(self):
+        """Set up test fixtures with a model that has max_seq_len configured."""
+        self.model = DummyOpenAIModel()
+        self.model.max_seq_len = 4096
+
+    def test_max_tokens_clamped_when_exceeds_max_seq_len(self):
+        """Test that max_tokens is clamped to max_seq_len when it exceeds the limit."""
+        request_data = {"max_tokens": 8192}
+        result = self.model._update_old_fields(request_data)
+
+        assert result.get("max_tokens") == 4096
+        assert result.get("max_completion_tokens") == 4096
+
+    def test_max_completion_tokens_clamped_when_exceeds_max_seq_len(self):
+        """Test that max_completion_tokens is clamped to max_seq_len when it exceeds the limit."""
+        request_data = {"max_completion_tokens": 8192}
+        result = self.model._update_old_fields(request_data)
+
+        assert result.get("max_tokens") == 4096
+        assert result.get("max_completion_tokens") == 4096
+
+    def test_max_tokens_unchanged_when_within_max_seq_len(self):
+        """Test that max_tokens is not changed when it is within max_seq_len."""
+        request_data = {"max_tokens": 2048}
+        result = self.model._update_old_fields(request_data)
+
+        assert result.get("max_tokens") == 2048
+        assert result.get("max_completion_tokens") == 2048
+
+    def test_max_completion_tokens_unchanged_when_within_max_seq_len(self):
+        """Test that max_completion_tokens is not changed when it is within max_seq_len."""
+        request_data = {"max_completion_tokens": 2048}
+        result = self.model._update_old_fields(request_data)
+
+        assert result.get("max_tokens") == 2048
+        assert result.get("max_completion_tokens") == 2048
+
+    def test_max_tokens_equal_to_max_seq_len_unchanged(self):
+        """Test that max_tokens equal to max_seq_len is not clamped."""
+        request_data = {"max_tokens": 4096}
+        result = self.model._update_old_fields(request_data)
+
+        assert result.get("max_tokens") == 4096
+        assert result.get("max_completion_tokens") == 4096
+
+    def test_no_clamping_when_max_seq_len_not_set(self):
+        """Test that no clamping occurs when max_seq_len is None."""
+        self.model.max_seq_len = None
+        request_data = {"max_tokens": 999999}
+        result = self.model._update_old_fields(request_data)
+
+        assert result.get("max_tokens") == 999999
+        assert result.get("max_completion_tokens") == 999999
+
+    def test_both_fields_clamped_when_max_completion_tokens_preferred(self):
+        """Test that both fields are clamped when max_completion_tokens is preferred and exceeds max_seq_len."""
+        request_data = {"max_tokens": 1000, "max_completion_tokens": 8192}
+        result = self.model._update_old_fields(request_data)
+
+        # max_completion_tokens takes priority, both should be clamped to max_seq_len
+        assert result.get("max_tokens") == 4096
+        assert result.get("max_completion_tokens") == 4096


### PR DESCRIPTION
### Why

When callers send max_tokens exceeding the model's max sequence length (e.g. 255K against a 128K context model), it can cause degraded throughput by disabling speculative decoding or triggering suboptimal memory allocation.

This change:
- Adds `max_seq_len` attribute to `OpenAIModelClass`, auto-detected from the backend's `/v1/models` response (`max_model_len` field) at init time
- Prefers the model card matching `self.model` when detecting `max_model_len`, falling back to the first available model card if no match is found
- Ensures the detected `max_model_len` is cast to `int` before assignment to guard against non-integer values
- Clamps `max_tokens` and `max_completion_tokens` to `max_seq_len` in `_update_old_fields` (cheap integer comparison, no overhead during streaming)
- Falls back gracefully: if backend doesn't expose `max_model_len`, no clamping occurs. Subclasses can also set `max_seq_len` explicitly.

### How

*

### Tests

- vllm, sglang, trt-llm was tested
- Added unit tests in `tests/runners/test_openai_update_old_fields.py` covering:
  - `max_tokens` and `max_completion_tokens` are clamped to `max_seq_len` when they exceed it
  - Values within or equal to `max_seq_len` are left unchanged
  - No clamping occurs when `max_seq_len` is `None`

### Notes

*