### PR TITLE
feat(runner): redirect local runner stdout/stderr to fluentd

### DIFF
--- a/clarifai/runners/server.py
+++ b/clarifai/runners/server.py
@@ -32,13 +32,13 @@ def _redirect_stdio_for_dev_pod():
         os.close(fd)
     except Exception as e:
         logger.warning(f"Failed to redirect stdout/stderr to /proc/1/fd/1: {e}")
+    finally:
+        if fd is not None:
+            os.close(fd)
 
 
 def main():
     _redirect_stdio_for_dev_pod()
-        finally:
-            if fd is not None:
-                os.close(fd)
 
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/clarifai/runners/server.py
+++ b/clarifai/runners/server.py
@@ -5,6 +5,7 @@ and starts the server.
 
 import argparse
 import os
+import sys
 from concurrent import futures
 from typing import Optional
 
@@ -20,6 +21,16 @@ from clarifai.utils.secrets import get_secrets_path, load_secrets, start_secrets
 
 
 def main():
+    if os.environ.get("CLARIFAI_DEV_POD") == "true":
+        # Redirect stdout/stderr to process 1's stdout so fluentd can capture the logs
+        try:
+            fd = os.open('/proc/1/fd/1', os.O_WRONLY)
+            os.dup2(fd, sys.stdout.fileno())
+            os.dup2(fd, sys.stderr.fileno())
+            os.close(fd)
+        except Exception as e:
+            logger.warning(f"Failed to redirect stdout/stderr to /proc/1/fd/1: {e}")
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--port',

--- a/clarifai/runners/server.py
+++ b/clarifai/runners/server.py
@@ -20,16 +20,22 @@ from clarifai.utils.logging import logger
 from clarifai.utils.secrets import get_secrets_path, load_secrets, start_secrets_watcher
 
 
+def _redirect_stdio_for_dev_pod():
+    if os.environ.get("CLARIFAI_DEV_POD") != "true":
+        return
+
+    # Redirect stdout/stderr to process 1's stdout so fluentd can capture the logs
+    try:
+        fd = os.open('/proc/1/fd/1', os.O_WRONLY)
+        os.dup2(fd, sys.stdout.fileno())
+        os.dup2(fd, sys.stderr.fileno())
+        os.close(fd)
+    except Exception as e:
+        logger.warning(f"Failed to redirect stdout/stderr to /proc/1/fd/1: {e}")
+
+
 def main():
-    if os.environ.get("CLARIFAI_DEV_POD") == "true":
-        # Redirect stdout/stderr to process 1's stdout so fluentd can capture the logs
-        fd = None
-        try:
-            fd = os.open('/proc/1/fd/1', os.O_WRONLY)
-            os.dup2(fd, sys.stdout.fileno())
-            os.dup2(fd, sys.stderr.fileno())
-        except Exception as e:
-            logger.warning(f"Failed to redirect stdout/stderr to /proc/1/fd/1: {e}")
+    _redirect_stdio_for_dev_pod()
         finally:
             if fd is not None:
                 os.close(fd)

--- a/clarifai/runners/server.py
+++ b/clarifai/runners/server.py
@@ -23,13 +23,16 @@ from clarifai.utils.secrets import get_secrets_path, load_secrets, start_secrets
 def main():
     if os.environ.get("CLARIFAI_DEV_POD") == "true":
         # Redirect stdout/stderr to process 1's stdout so fluentd can capture the logs
+        fd = None
         try:
             fd = os.open('/proc/1/fd/1', os.O_WRONLY)
             os.dup2(fd, sys.stdout.fileno())
             os.dup2(fd, sys.stderr.fileno())
-            os.close(fd)
         except Exception as e:
             logger.warning(f"Failed to redirect stdout/stderr to /proc/1/fd/1: {e}")
+        finally:
+            if fd is not None:
+                os.close(fd)
 
     parser = argparse.ArgumentParser()
     parser.add_argument(


### PR DESCRIPTION
When running a local runner inside a developer pod, standard output and standard error are redirected to `/proc/1/fd/1` using `os.dup2`. This allows fluentd to capture and route the local runner's logs as part of the main pod logs. This behavior is enabled when the `CLARIFAI_DEV_POD` environment variable is set to `"true"`.
