### PR TITLE
 Auto-create compute cluster/nodepool for pipeline run 

### DIFF
--- a/clarifai/cli/pipeline.py
+++ b/clarifai/cli/pipeline.py
@@ -13,6 +13,73 @@ from clarifai.utils.cli import (
 from clarifai.utils.logging import logger
 
 
+def _ensure_pipeline_compute(
+    ctx, user_id, instance, cloud, region, compute_cluster_id, nodepool_id
+):
+    """Resolve instance type and auto-create compute cluster/nodepool if needed.
+
+    Uses the same deterministic ID and get-or-create pattern as model deploy.
+
+    Returns:
+        tuple: (compute_cluster_id, nodepool_id)
+    """
+    from clarifai.utils.compute_presets import (
+        get_compute_cluster_config,
+        get_deploy_compute_cluster_id,
+        get_deploy_nodepool_id,
+        get_nodepool_config,
+        resolve_gpu,
+    )
+
+    gpu_preset = resolve_gpu(instance, pat=ctx.obj.current.pat, base_url=ctx.obj.current.api_base)
+    if not gpu_preset:
+        raise ValueError(
+            f"Unknown instance type '{instance}'. Use 'clarifai list-instances' to see available options."
+        )
+
+    cloud = cloud or gpu_preset.get('cloud_provider', 'aws')
+    region = region or gpu_preset.get('region', 'us-east-1')
+    instance_type_id = gpu_preset['instance_type_id']
+
+    cc_id = compute_cluster_id or get_deploy_compute_cluster_id(cloud, region)
+    np_id = nodepool_id or get_deploy_nodepool_id(instance_type_id)
+
+    from clarifai.client.user import User
+
+    user = User(user_id=user_id, pat=ctx.obj.current.pat, base_url=ctx.obj.current.api_base)
+
+    # Get-or-create compute cluster
+    try:
+        user.compute_cluster(cc_id)
+    except Exception:
+        logger.info(f"Creating compute cluster '{cc_id}'...")
+        cc_config = get_compute_cluster_config(user_id, cloud, region)
+        user.create_compute_cluster(compute_cluster_config=cc_config)
+
+    # Get-or-create nodepool
+    from clarifai.client.compute_cluster import ComputeCluster
+
+    cc = ComputeCluster(
+        compute_cluster_id=cc_id,
+        user_id=user_id,
+        pat=ctx.obj.current.pat,
+        base_url=ctx.obj.current.api_base,
+    )
+    try:
+        cc.nodepool(np_id)
+    except Exception:
+        logger.info(f"Creating nodepool '{np_id}'...")
+        np_config = get_nodepool_config(
+            instance_type_id=instance_type_id,
+            compute_cluster_id=cc_id,
+            user_id=user_id,
+            compute_info=gpu_preset.get("inference_compute_info"),
+        )
+        cc.create_nodepool(nodepool_config=np_config)
+
+    return cc_id, np_id
+
+
 @cli.group(
     ['pipeline', 'pl'],
     cls=AliasedGroup,
@@ -55,9 +122,30 @@ def upload(path, no_lockfile):
 )
 @click.option('--user_id', required=False, help='User ID of the pipeline.')
 @click.option('--app_id', required=False, help='App ID that contains the pipeline.')
-@click.option('--nodepool_id', required=False, help='Nodepool ID to run the pipeline on.')
 @click.option(
-    '--compute_cluster_id', required=False, help='Compute Cluster ID to run the pipeline on.'
+    '--nodepool_id',
+    required=False,
+    help='[Advanced] Existing nodepool ID (skip auto-creation).',
+)
+@click.option(
+    '--compute_cluster_id',
+    required=False,
+    help='[Advanced] Existing compute cluster ID (skip auto-creation).',
+)
+@click.option(
+    '--instance',
+    default=None,
+    help='Hardware instance type (e.g., g5.xlarge, A10G). Auto-creates compute cluster and nodepool.',
+)
+@click.option(
+    '--cloud',
+    default=None,
+    help='Cloud provider (e.g., aws, gcp). Auto-detected from --instance if omitted.',
+)
+@click.option(
+    '--region',
+    default=None,
+    help='Cloud region (e.g., us-east-1). Auto-detected from --instance if omitted.',
 )
 @click.option('--pipeline_url', required=False, help='Pipeline URL to run.')
 @click.option(
@@ -106,6 +194,9 @@ def run(
     app_id,
     nodepool_id,
     compute_cluster_id,
+    instance,
+    cloud,
+    region,
     pipeline_url,
     timeout,
     monitor_interval,
@@ -150,6 +241,11 @@ def run(
         )
         nodepool_id = config_data.get('nodepool_id', nodepool_id)
         compute_cluster_id = config_data.get('compute_cluster_id', compute_cluster_id)
+        # Read compute section for auto-creation support
+        compute_section = config_data.get('compute', {})
+        instance = instance or compute_section.get('instance')
+        cloud = cloud or compute_section.get('cloud')
+        region = region or compute_section.get('region')
         pipeline_url = config_data.get('pipeline_url', pipeline_url)
         timeout = config_data.get('timeout', timeout)
         monitor_interval = config_data.get('monitor_interval', monitor_interval)
@@ -169,9 +265,19 @@ def run(
         if not compute_cluster_id:
             compute_cluster_id = ctx.obj.current.get('compute_cluster_id', '')
 
-    # compute_cluster_id and nodepool_id are mandatory regardless of whether pipeline_url is provided
+    # Auto-resolve compute cluster and nodepool from --instance if not explicitly provided
     if not compute_cluster_id or not nodepool_id:
-        raise ValueError("--compute_cluster_id and --nodepool_id are mandatory parameters.")
+        if instance:
+            compute_cluster_id, nodepool_id = _ensure_pipeline_compute(
+                ctx, user_id, instance, cloud, region, compute_cluster_id, nodepool_id
+            )
+        else:
+            raise ValueError(
+                "--instance is required when --compute_cluster_id and --nodepool_id are not both provided.\n"
+                "  Example: clarifai pipeline run --instance g5.xlarge\n"
+                "  Or provide both: --compute_cluster_id <id> --nodepool_id <id>\n"
+                "  List available instances: clarifai list-instances"
+            )
 
     # When monitor flag is used, pipeline_version_run_id is mandatory
     if monitor and not pipeline_version_run_id:

--- a/clarifai/cli/pipeline.py
+++ b/clarifai/cli/pipeline.py
@@ -241,8 +241,13 @@ def run(
         )
         nodepool_id = config_data.get('nodepool_id', nodepool_id)
         compute_cluster_id = config_data.get('compute_cluster_id', compute_cluster_id)
-        # Read compute section for auto-creation support
-        compute_section = config_data.get('compute', {})
+        # Read compute section from inside pipeline config for auto-creation support
+        pipeline_sect = (
+            config_data.get('pipeline', {})
+            if isinstance(config_data.get('pipeline'), dict)
+            else {}
+        )
+        compute_section = pipeline_sect.get('compute', {})
         instance = instance or compute_section.get('instance')
         cloud = cloud or compute_section.get('cloud')
         region = region or compute_section.get('region')

--- a/clarifai/runners/pipelines/pipeline_builder.py
+++ b/clarifai/runners/pipelines/pipeline_builder.py
@@ -281,6 +281,11 @@ class PipelineBuilder:
                 lockfile_data["pipeline"]["config"] = {}
             lockfile_data["pipeline"]["config"]["step_version_secrets"] = step_version_secrets
 
+        # Preserve compute section from pipeline config (used by `clarifai pipeline run`)
+        compute = pipeline_config.get("compute")
+        if compute:
+            lockfile_data["pipeline"]["compute"] = compute
+
         return lockfile_data
 
     def update_lockfile_with_pipeline_info(
@@ -331,6 +336,11 @@ class PipelineBuilder:
             if "config" not in lockfile_data["pipeline"]:
                 lockfile_data["pipeline"]["config"] = {}
             lockfile_data["pipeline"]["config"]["step_version_secrets"] = step_version_secrets
+
+        # Preserve compute section from pipeline config (used by `clarifai pipeline run`)
+        compute = pipeline_config.get("compute")
+        if compute:
+            lockfile_data["pipeline"]["compute"] = compute
 
         return lockfile_data
 

--- a/tests/cli/test_pipeline.py
+++ b/tests/cli/test_pipeline.py
@@ -1476,9 +1476,7 @@ class TestPipelineRunCommand:
 
             assert result.exit_code != 0
             assert result.exception is not None
-            assert '--compute_cluster_id and --nodepool_id are mandatory parameters' in str(
-                result.exception
-            )
+            assert '--instance is required' in str(result.exception)
 
     @patch('clarifai.client.pipeline.Pipeline')
     @patch('clarifai.utils.cli.validate_context')

--- a/tests/cli/test_pipeline_compute.py
+++ b/tests/cli/test_pipeline_compute.py
@@ -1,0 +1,445 @@
+"""Tests for pipeline run compute auto-resolution (--instance flag).
+
+Mirrors the patterns from test_model_deploy.py TestComputeConfigs and
+TestModelDeployerValidation, applied to the pipeline run CLI.
+"""
+
+from unittest.mock import Mock, patch
+
+import yaml
+from click.testing import CliRunner
+
+from clarifai.cli.pipeline import run
+
+
+class _MockContext:
+    """Reusable mock CLI context for pipeline tests."""
+
+    def __init__(self):
+        self.pat = 'test-pat'
+        self.api_base = 'https://api.clarifai.com'
+        self.user_id = 'test-user'
+
+    def get(self, key, default=None):
+        return getattr(self, key, default)
+
+
+class _MockConfig:
+    def __init__(self):
+        self.current = _MockContext()
+
+
+# Common CLI args for a valid pipeline identity (used across multiple tests)
+_PIPELINE_IDENTITY_ARGS = [
+    '--pipeline_id',
+    'test-pipeline',
+    '--pipeline_version_id',
+    'v1',
+    '--user_id',
+    'test-user',
+    '--app_id',
+    'test-app',
+]
+
+
+class TestPipelineRunInstanceFlag:
+    """Test --instance flag auto-creates compute infrastructure for pipeline run."""
+
+    @patch('clarifai.client.pipeline.Pipeline')
+    @patch('clarifai.utils.cli.validate_context')
+    @patch('clarifai.cli.pipeline._ensure_pipeline_compute')
+    def test_instance_flag_triggers_auto_compute(
+        self, mock_ensure, mock_validate, mock_pipeline_class
+    ):
+        """--instance without cc/np calls _ensure_pipeline_compute and passes resolved IDs."""
+        mock_ensure.return_value = ('deploy-cc-aws-us-east-1', 'deploy-np-g5-xlarge')
+        mock_pipeline = Mock()
+        mock_pipeline.run.return_value = {'status': 'success'}
+        mock_pipeline_class.return_value = mock_pipeline
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                run,
+                _PIPELINE_IDENTITY_ARGS + ['--instance', 'g5.xlarge'],
+                obj=_MockConfig(),
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_ensure.assert_called_once()
+        # Verify auto-resolved IDs were passed to Pipeline
+        call_kwargs = mock_pipeline_class.call_args[1]
+        assert call_kwargs['compute_cluster_id'] == 'deploy-cc-aws-us-east-1'
+        assert call_kwargs['nodepool_id'] == 'deploy-np-g5-xlarge'
+
+    @patch('clarifai.client.pipeline.Pipeline')
+    @patch('clarifai.utils.cli.validate_context')
+    def test_explicit_cc_np_skips_auto_compute(self, mock_validate, mock_pipeline_class):
+        """Explicit --compute_cluster_id + --nodepool_id bypasses auto-creation entirely."""
+        mock_pipeline = Mock()
+        mock_pipeline.run.return_value = {'status': 'success'}
+        mock_pipeline_class.return_value = mock_pipeline
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                run,
+                _PIPELINE_IDENTITY_ARGS
+                + [
+                    '--compute_cluster_id',
+                    'my-cc',
+                    '--nodepool_id',
+                    'my-np',
+                ],
+                obj=_MockConfig(),
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_pipeline_class.call_args[1]
+        assert call_kwargs['compute_cluster_id'] == 'my-cc'
+        assert call_kwargs['nodepool_id'] == 'my-np'
+
+    @patch('clarifai.utils.cli.validate_context')
+    def test_no_instance_no_cc_np_raises_error(self, mock_validate):
+        """Missing both --instance and --compute_cluster_id/--nodepool_id raises clear error."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                run,
+                _PIPELINE_IDENTITY_ARGS,
+                obj=_MockConfig(),
+            )
+
+        assert result.exit_code != 0
+        assert '--instance is required' in str(result.exception)
+
+    @patch('clarifai.client.pipeline.Pipeline')
+    @patch('clarifai.utils.cli.validate_context')
+    @patch('clarifai.cli.pipeline._ensure_pipeline_compute')
+    def test_instance_with_cloud_region_override(
+        self, mock_ensure, mock_validate, mock_pipeline_class
+    ):
+        """--instance + --cloud + --region passes overrides to _ensure_pipeline_compute."""
+        mock_ensure.return_value = ('deploy-cc-gcp-us-central1', 'deploy-np-a10g')
+        mock_pipeline = Mock()
+        mock_pipeline.run.return_value = {'status': 'success'}
+        mock_pipeline_class.return_value = mock_pipeline
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                run,
+                _PIPELINE_IDENTITY_ARGS
+                + [
+                    '--instance',
+                    'a10g',
+                    '--cloud',
+                    'gcp',
+                    '--region',
+                    'us-central1',
+                ],
+                obj=_MockConfig(),
+            )
+
+        assert result.exit_code == 0, result.output
+        # Verify cloud/region were forwarded
+        call_args = mock_ensure.call_args
+        assert call_args[0][3] == 'gcp'  # cloud
+        assert call_args[0][4] == 'us-central1'  # region
+
+    @patch('clarifai.client.pipeline.Pipeline')
+    @patch('clarifai.utils.cli.validate_context')
+    @patch('clarifai.cli.pipeline._ensure_pipeline_compute')
+    def test_instance_from_config_yaml(self, mock_ensure, mock_validate, mock_pipeline_class):
+        """compute.instance in config.yaml is used when --instance is not passed."""
+        mock_ensure.return_value = ('deploy-cc-aws-us-east-1', 'deploy-np-g5-xlarge')
+        mock_pipeline = Mock()
+        mock_pipeline.run.return_value = {'status': 'success'}
+        mock_pipeline_class.return_value = mock_pipeline
+
+        config_data = {
+            'pipeline': {
+                'id': 'test-pipeline',
+                'version_id': 'v1',
+                'user_id': 'test-user',
+                'app_id': 'test-app',
+            },
+            'compute': {
+                'instance': 'g5.xlarge',
+            },
+        }
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open('run-config.yaml', 'w') as f:
+                yaml.safe_dump(config_data, f)
+
+            result = runner.invoke(
+                run,
+                ['--config', 'run-config.yaml'],
+                obj=_MockConfig(),
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_ensure.assert_called_once()
+        # instance arg should be 'g5.xlarge' from config
+        assert mock_ensure.call_args[0][2] == 'g5.xlarge'
+
+    @patch('clarifai.client.pipeline.Pipeline')
+    @patch('clarifai.utils.cli.validate_context')
+    @patch('clarifai.cli.pipeline._ensure_pipeline_compute')
+    def test_cli_instance_overrides_config(self, mock_ensure, mock_validate, mock_pipeline_class):
+        """CLI --instance takes precedence over config.yaml compute.instance."""
+        mock_ensure.return_value = ('deploy-cc-aws-us-east-1', 'deploy-np-l40s')
+        mock_pipeline = Mock()
+        mock_pipeline.run.return_value = {'status': 'success'}
+        mock_pipeline_class.return_value = mock_pipeline
+
+        config_data = {
+            'pipeline': {
+                'id': 'test-pipeline',
+                'version_id': 'v1',
+                'user_id': 'test-user',
+                'app_id': 'test-app',
+            },
+            'compute': {
+                'instance': 'g5.xlarge',  # config says g5.xlarge
+            },
+        }
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open('run-config.yaml', 'w') as f:
+                yaml.safe_dump(config_data, f)
+
+            result = runner.invoke(
+                run,
+                ['--config', 'run-config.yaml', '--instance', 'l40s'],  # CLI says l40s
+                obj=_MockConfig(),
+            )
+
+        assert result.exit_code == 0, result.output
+        # CLI flag should win
+        assert mock_ensure.call_args[0][2] == 'l40s'
+
+    @patch('clarifai.client.pipeline.Pipeline')
+    @patch('clarifai.utils.cli.validate_context')
+    @patch('clarifai.cli.pipeline._ensure_pipeline_compute')
+    def test_config_cloud_region_used_when_cli_omitted(
+        self, mock_ensure, mock_validate, mock_pipeline_class
+    ):
+        """compute.cloud and compute.region from config used when CLI flags omitted."""
+        mock_ensure.return_value = ('deploy-cc-gcp-eu-west1', 'deploy-np-a10g')
+        mock_pipeline = Mock()
+        mock_pipeline.run.return_value = {'status': 'success'}
+        mock_pipeline_class.return_value = mock_pipeline
+
+        config_data = {
+            'pipeline': {
+                'id': 'test-pipeline',
+                'version_id': 'v1',
+                'user_id': 'test-user',
+                'app_id': 'test-app',
+            },
+            'compute': {
+                'instance': 'a10g',
+                'cloud': 'gcp',
+                'region': 'eu-west1',
+            },
+        }
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open('run-config.yaml', 'w') as f:
+                yaml.safe_dump(config_data, f)
+
+            result = runner.invoke(
+                run,
+                ['--config', 'run-config.yaml'],
+                obj=_MockConfig(),
+            )
+
+        assert result.exit_code == 0, result.output
+        call_args = mock_ensure.call_args[0]
+        assert call_args[2] == 'a10g'  # instance
+        assert call_args[3] == 'gcp'  # cloud from config
+        assert call_args[4] == 'eu-west1'  # region from config
+
+    @patch('clarifai.client.pipeline.Pipeline')
+    @patch('clarifai.utils.cli.validate_context')
+    @patch('clarifai.cli.pipeline._ensure_pipeline_compute')
+    def test_pipeline_url_with_instance(self, mock_ensure, mock_validate, mock_pipeline_class):
+        """--pipeline_url + --instance works (url-based run with auto-compute)."""
+        mock_ensure.return_value = ('deploy-cc-aws-us-east-1', 'deploy-np-g5-xlarge')
+        mock_pipeline = Mock()
+        mock_pipeline.run.return_value = {'status': 'success'}
+        mock_pipeline_class.return_value = mock_pipeline
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                run,
+                [
+                    '--pipeline_url',
+                    'https://clarifai.com/user/app/pipelines/my-pl',
+                    '--instance',
+                    'g5.xlarge',
+                ],
+                obj=_MockConfig(),
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_ensure.assert_called_once()
+        call_kwargs = mock_pipeline_class.call_args[1]
+        assert call_kwargs['nodepool_id'] == 'deploy-np-g5-xlarge'
+        assert call_kwargs['compute_cluster_id'] == 'deploy-cc-aws-us-east-1'
+
+
+class TestEnsurePipelineCompute:
+    """Test _ensure_pipeline_compute helper directly (mirrors TestComputeConfigs from model deploy)."""
+
+    @patch('clarifai.client.compute_cluster.ComputeCluster')
+    @patch('clarifai.client.user.User')
+    @patch('clarifai.utils.compute_presets.resolve_gpu')
+    def test_creates_cluster_and_nodepool_when_missing(
+        self, mock_resolve_gpu, mock_user_class, mock_cc_class
+    ):
+        """When cluster and nodepool don't exist, both are auto-created."""
+        from clarifai.cli.pipeline import _ensure_pipeline_compute
+
+        mock_resolve_gpu.return_value = {
+            'instance_type_id': 'g5.xlarge',
+            'cloud_provider': 'aws',
+            'region': 'us-east-1',
+            'inference_compute_info': {'cpu_limit': '4', 'num_accelerators': 1},
+        }
+        mock_user = Mock()
+        mock_user.compute_cluster.side_effect = Exception("not found")
+        mock_user_class.return_value = mock_user
+
+        mock_cc = Mock()
+        mock_cc.nodepool.side_effect = Exception("not found")
+        mock_cc_class.return_value = mock_cc
+
+        ctx = Mock()
+        ctx.obj.current.pat = 'test-pat'
+        ctx.obj.current.api_base = 'https://api.clarifai.com'
+
+        cc_id, np_id = _ensure_pipeline_compute(
+            ctx, 'test-user', 'g5.xlarge', None, None, None, None
+        )
+
+        assert cc_id == 'deploy-cc-aws-us-east-1'
+        assert np_id == 'deploy-np-g5-xlarge'
+        mock_user.create_compute_cluster.assert_called_once()
+        mock_cc.create_nodepool.assert_called_once()
+
+    @patch('clarifai.client.compute_cluster.ComputeCluster')
+    @patch('clarifai.client.user.User')
+    @patch('clarifai.utils.compute_presets.resolve_gpu')
+    def test_reuses_existing_cluster_and_nodepool(
+        self, mock_resolve_gpu, mock_user_class, mock_cc_class
+    ):
+        """When cluster and nodepool already exist, no creation calls are made."""
+        from clarifai.cli.pipeline import _ensure_pipeline_compute
+
+        mock_resolve_gpu.return_value = {
+            'instance_type_id': 'g5.xlarge',
+            'cloud_provider': 'aws',
+            'region': 'us-east-1',
+            'inference_compute_info': {},
+        }
+        mock_user = Mock()
+        mock_user.compute_cluster.return_value = Mock()  # exists
+        mock_user_class.return_value = mock_user
+
+        mock_cc = Mock()
+        mock_cc.nodepool.return_value = Mock()  # exists
+        mock_cc_class.return_value = mock_cc
+
+        ctx = Mock()
+        ctx.obj.current.pat = 'test-pat'
+        ctx.obj.current.api_base = 'https://api.clarifai.com'
+
+        cc_id, np_id = _ensure_pipeline_compute(
+            ctx, 'test-user', 'g5.xlarge', None, None, None, None
+        )
+
+        assert cc_id == 'deploy-cc-aws-us-east-1'
+        assert np_id == 'deploy-np-g5-xlarge'
+        mock_user.create_compute_cluster.assert_not_called()
+        mock_cc.create_nodepool.assert_not_called()
+
+    @patch('clarifai.client.compute_cluster.ComputeCluster')
+    @patch('clarifai.client.user.User')
+    @patch('clarifai.utils.compute_presets.resolve_gpu')
+    def test_custom_cloud_region(self, mock_resolve_gpu, mock_user_class, mock_cc_class):
+        """Explicit cloud/region overrides auto-detected values from resolve_gpu."""
+        from clarifai.cli.pipeline import _ensure_pipeline_compute
+
+        mock_resolve_gpu.return_value = {
+            'instance_type_id': 'gpu-nvidia-a10g',
+            'cloud_provider': 'aws',  # will be overridden
+            'region': 'us-east-1',  # will be overridden
+            'inference_compute_info': {},
+        }
+        mock_user = Mock()
+        mock_user_class.return_value = mock_user
+        mock_cc = Mock()
+        mock_cc_class.return_value = mock_cc
+
+        ctx = Mock()
+        ctx.obj.current.pat = 'test-pat'
+        ctx.obj.current.api_base = 'https://api.clarifai.com'
+
+        cc_id, np_id = _ensure_pipeline_compute(
+            ctx, 'test-user', 'a10g', 'gcp', 'us-central1', None, None
+        )
+
+        assert cc_id == 'deploy-cc-gcp-us-central1'
+        assert np_id == 'deploy-np-gpu-nvidia-a10g'
+
+    @patch('clarifai.utils.compute_presets.resolve_gpu')
+    def test_unknown_instance_raises_error(self, mock_resolve_gpu):
+        """Unknown instance type raises ValueError."""
+        from clarifai.cli.pipeline import _ensure_pipeline_compute
+
+        mock_resolve_gpu.side_effect = ValueError("Unknown GPU")
+
+        ctx = Mock()
+        ctx.obj.current.pat = 'test-pat'
+        ctx.obj.current.api_base = 'https://api.clarifai.com'
+
+        import pytest
+
+        with pytest.raises(ValueError):
+            _ensure_pipeline_compute(ctx, 'test-user', 'nonexistent-gpu', None, None, None, None)
+
+    @patch('clarifai.client.compute_cluster.ComputeCluster')
+    @patch('clarifai.client.user.User')
+    @patch('clarifai.utils.compute_presets.resolve_gpu')
+    def test_explicit_cc_id_preserved(self, mock_resolve_gpu, mock_user_class, mock_cc_class):
+        """When compute_cluster_id is explicitly provided, it's used instead of auto-generated."""
+        from clarifai.cli.pipeline import _ensure_pipeline_compute
+
+        mock_resolve_gpu.return_value = {
+            'instance_type_id': 'g5.xlarge',
+            'cloud_provider': 'aws',
+            'region': 'us-east-1',
+            'inference_compute_info': {},
+        }
+        mock_user = Mock()
+        mock_user_class.return_value = mock_user
+        mock_cc = Mock()
+        mock_cc_class.return_value = mock_cc
+
+        ctx = Mock()
+        ctx.obj.current.pat = 'test-pat'
+        ctx.obj.current.api_base = 'https://api.clarifai.com'
+
+        cc_id, np_id = _ensure_pipeline_compute(
+            ctx, 'test-user', 'g5.xlarge', None, None, 'my-custom-cc', None
+        )
+
+        assert cc_id == 'my-custom-cc'
+        assert np_id == 'deploy-np-g5-xlarge'

--- a/tests/cli/test_pipeline_compute.py
+++ b/tests/cli/test_pipeline_compute.py
@@ -163,9 +163,9 @@ class TestPipelineRunInstanceFlag:
                 'version_id': 'v1',
                 'user_id': 'test-user',
                 'app_id': 'test-app',
-            },
-            'compute': {
-                'instance': 'g5.xlarge',
+                'compute': {
+                    'instance': 'g5.xlarge',
+                },
             },
         }
 
@@ -201,9 +201,9 @@ class TestPipelineRunInstanceFlag:
                 'version_id': 'v1',
                 'user_id': 'test-user',
                 'app_id': 'test-app',
-            },
-            'compute': {
-                'instance': 'g5.xlarge',  # config says g5.xlarge
+                'compute': {
+                    'instance': 'g5.xlarge',  # config says g5.xlarge
+                },
             },
         }
 
@@ -240,11 +240,11 @@ class TestPipelineRunInstanceFlag:
                 'version_id': 'v1',
                 'user_id': 'test-user',
                 'app_id': 'test-app',
-            },
-            'compute': {
-                'instance': 'a10g',
-                'cloud': 'gcp',
-                'region': 'eu-west1',
+                'compute': {
+                    'instance': 'a10g',
+                    'cloud': 'gcp',
+                    'region': 'eu-west1',
+                },
             },
         }
 

--- a/tests/cli/test_pipeline_lockfile.py
+++ b/tests/cli/test_pipeline_lockfile.py
@@ -101,6 +101,70 @@ spec:
             assert saved_data["pipeline"]["id"] == "test-pipeline"
             assert saved_data["pipeline"]["version_id"] == "pipeline-version-456"
 
+    def test_generate_lockfile_preserves_compute_section(self):
+        """Test that compute section inside pipeline config is preserved in lockfile."""
+        config_with_compute = {
+            "pipeline": {
+                "id": "test-pipeline",
+                "user_id": "test-user",
+                "app_id": "test-app",
+                "step_directories": ["stepA"],
+                "orchestration_spec": {
+                    "argo_orchestration_spec": """
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: test-workflow
+spec:
+  entrypoint: sequence
+  templates:
+  - name: sequence
+    steps:
+    - - name: step1
+        templateRef:
+          name: users/test-user/apps/test-app/pipeline_steps/stepA
+          template: users/test-user/apps/test-app/pipeline_steps/stepA
+                    """
+                },
+                "compute": {
+                    "instance": "g5.xlarge",
+                    "cloud": "aws",
+                    "region": "us-east-1",
+                },
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            yaml.dump(config_with_compute, f)
+            temp_path = f.name
+
+        try:
+            builder = PipelineBuilder(temp_path)
+            builder.uploaded_step_versions = {"stepA": "version-123"}
+
+            # Test both lockfile generation methods
+            lockfile_data = builder.generate_lockfile_data(
+                pipeline_id="test-pipeline", pipeline_version_id="v1"
+            )
+            assert lockfile_data["pipeline"]["compute"]["instance"] == "g5.xlarge"
+            assert lockfile_data["pipeline"]["compute"]["cloud"] == "aws"
+            assert lockfile_data["pipeline"]["compute"]["region"] == "us-east-1"
+
+            lockfile_data2 = builder.prepare_lockfile_with_step_versions()
+            assert lockfile_data2["pipeline"]["compute"]["instance"] == "g5.xlarge"
+        finally:
+            os.unlink(temp_path)
+
+    def test_generate_lockfile_no_compute_section(self, temp_config_file):
+        """Test that lockfile works fine when config has no compute section."""
+        builder = PipelineBuilder(temp_config_file)
+        builder.uploaded_step_versions = {"stepA": "version-123"}
+
+        lockfile_data = builder.generate_lockfile_data(
+            pipeline_id="test-pipeline", pipeline_version_id="v1"
+        )
+        assert "compute" not in lockfile_data["pipeline"]
+
     def test_generate_lockfile_data_no_step_versions(self, temp_config_file):
         """Test generating lockfile data when no step versions are uploaded."""
         builder = PipelineBuilder(temp_config_file)


### PR DESCRIPTION
 ## Summary                                                                                                       
  - Add `--instance`, `--cloud`, `--region` options to `clarifai pipeline run`, matching the pattern from `clarifai
   model deploy` (PR #960)                                                                                         
  - `--compute_cluster_id` and `--nodepool_id` are no longer mandatory — they are auto-derived from `--instance`
  using deterministic IDs and get-or-create pattern                                                                
  - Reuses existing `compute_presets.py` utilities (resolve_gpu, deterministic ID generation, cluster/nodepool
  config) with zero duplication                                                                                    
  - Supports reading `compute.instance` / `compute.cloud` / `compute.region` from config.yaml
                                                                                                                   
  ## Usage                                                  
  ```bash                                                                                                          
  # Before: required explicit IDs                           
  clarifai pipeline run --compute_cluster_id my-cc --nodepool_id my-np ...                                         
   
  # After: just specify instance type                                                                              
  clarifai pipeline run --instance g5.xlarge ...            
                                                                                                                   
  # Or put it in config.yaml under compute.instance         
  # Advanced users can still pass --compute_cluster_id / --nodepool_id directly
                                                                                                                   