### PR TITLE
Skip legacy training template tests (deprecated by backend)

### DIFF
--- a/tests/test_model_train.py
+++ b/tests/test_model_train.py
@@ -37,6 +37,10 @@ class Testmodeltrain:
             model_id=CREATE_MODEL_ID_1, model_type_id='text-classifier'
         )
 
+    @pytest.mark.skip(
+        reason="Legacy training template API has been deprecated server-side. "
+        "Use the pipelines-based training path instead."
+    )
     def test_model_templates(self):
         model_types = self.app.list_trainable_model_types()
         templates = self.visual_classifier_model.list_training_templates()
@@ -46,6 +50,10 @@ class Testmodeltrain:
         assert len(model_types) == 8  # list trainable model types test
         assert len(templates) >= 11  # list training templates test
 
+    @pytest.mark.skip(
+        reason="Legacy training template API has been deprecated server-side. "
+        "Use the pipelines-based training path instead."
+    )
     def test_model_params(self):
         model_params = self.visual_classifier_model.get_params(
             template='MMClassification_AdvancedConfig', save_to='tests/assets/model_params.yaml'


### PR DESCRIPTION
## Summary

- Adds `@pytest.mark.skip` to `test_model_templates` and `test_model_params` in `tests/test_model_train.py`
- These have been failing on every scheduled master CI run (macOS/Ubuntu/Windows × Python 3.11/3.12) for days, blocking CI on unrelated PRs

## Why

The legacy training template API has been deprecated server-side — the `ListModelTypes` endpoint no longer returns the `template` field with `model_type_enum_options`. As a result:

- `Model.list_training_templates()` returns `[]` → `assert 0 >= 11` fails
- `Model.get_params(template='MMClassification_AdvancedConfig')` has no `custom_config` key → `KeyError` fails

Training is now expected to go through the pipelines-based path (e.g. `clarifai pipeline run` with training pipelines).

## Follow-up

The SDK methods `Model.list_training_templates()` and `Model.get_params()` are effectively no-ops. A follow-up should decide whether to:
1. Remove them entirely (next major release), or
2. Replace them with pipeline-based template discovery

Tracked separately — this PR just unblocks CI.

## Test plan

- [x] `pytest tests/test_model_train.py` — both tests show SKIPPED with reason