### PR TITLE
ADX-172: Add code-first Pipeline DSL with CLI generate/upload support

### DIFF
--- a/clarifai/cli/pipeline.py
+++ b/clarifai/cli/pipeline.py
@@ -110,7 +110,11 @@ def upload(path, no_lockfile):
 
     if os.path.isfile(path) and path.endswith('.py'):
         pipeline_obj = load_pipeline_from_file(path)
-        pipeline_obj.upload(no_lockfile=no_lockfile)
+        output_dir = os.path.join(
+            os.path.dirname(os.path.abspath(path)), f'generated-{pipeline_obj.id}'
+        )
+        pipeline_obj.generate(output_dir)
+        upload_pipeline(output_dir, no_lockfile=no_lockfile)
         return
 
     upload_pipeline(path, no_lockfile=no_lockfile)

--- a/clarifai/cli/pipeline.py
+++ b/clarifai/cli/pipeline.py
@@ -105,9 +105,35 @@ def upload(path, no_lockfile):
 
     PATH: Path to the pipeline configuration file or directory containing config.yaml. If not specified, the current directory is used by default.
     """
+    from clarifai.runners.pipelines import load_pipeline_from_file
     from clarifai.runners.pipelines.pipeline_builder import upload_pipeline
 
+    if os.path.isfile(path) and path.endswith('.py'):
+        pipeline_obj = load_pipeline_from_file(path)
+        pipeline_obj.upload(no_lockfile=no_lockfile)
+        return
+
     upload_pipeline(path, no_lockfile=no_lockfile)
+
+
+@pipeline.command('generate')
+@click.argument('path', type=click.Path(exists=True), required=True)
+@click.option(
+    '--output-dir',
+    type=click.Path(),
+    required=True,
+    help='Directory to write the generated pipeline config and step folders.',
+)
+def generate(path, output_dir):
+    """Generate YAML/config-based pipeline assets from a Python pipeline definition."""
+    from clarifai.runners.pipelines import load_pipeline_from_file
+
+    if not os.path.isfile(path) or not path.endswith('.py'):
+        raise ValueError('clarifai pipeline generate expects a Python file path.')
+
+    pipeline_obj = load_pipeline_from_file(path)
+    config_path = pipeline_obj.generate(output_dir)
+    logger.info(f"Generated pipeline assets at {config_path}")
 
 
 @pipeline.command()

--- a/clarifai/cli/pipeline.py
+++ b/clarifai/cli/pipeline.py
@@ -133,7 +133,7 @@ def generate(path, output_dir):
     from clarifai.runners.pipelines import load_pipeline_from_file
 
     if not os.path.isfile(path) or not path.endswith('.py'):
-        raise ValueError('clarifai pipeline generate expects a Python file path.')
+        raise click.UsageError('clarifai pipeline generate expects a Python file path.')
 
     pipeline_obj = load_pipeline_from_file(path)
     config_path = pipeline_obj.generate(output_dir)

--- a/clarifai/runners/pipelines/__init__.py
+++ b/clarifai/runners/pipelines/__init__.py
@@ -1,15 +1,22 @@
-from clarifai.runners.pipelines.compute import ComputeConfig
+from clarifai.runners.pipelines.compute import ComputeInfo
 from clarifai.runners.pipelines.pipeline import Pipeline, load_pipeline_from_file
-from clarifai.runners.pipelines.step import ExistingStepDefinition, OutputRef, StepDefinition, StepNode, step, step_ref
+from clarifai.runners.pipelines.step import (
+    ExistingStepDefinition,
+    OutputRef,
+    StepDefinition,
+    StepNode,
+    step,
+    step_ref,
+)
 
 __all__ = [
-	'ComputeConfig',
-	'ExistingStepDefinition',
-	'OutputRef',
-	'Pipeline',
-	'StepDefinition',
-	'StepNode',
-	'load_pipeline_from_file',
-	'step',
-	'step_ref',
+    'ComputeInfo',
+    'ExistingStepDefinition',
+    'OutputRef',
+    'Pipeline',
+    'StepDefinition',
+    'StepNode',
+    'load_pipeline_from_file',
+    'step',
+    'step_ref',
 ]

--- a/clarifai/runners/pipelines/__init__.py
+++ b/clarifai/runners/pipelines/__init__.py
@@ -1,13 +1,15 @@
 from clarifai.runners.pipelines.compute import ComputeConfig
 from clarifai.runners.pipelines.pipeline import Pipeline, load_pipeline_from_file
-from clarifai.runners.pipelines.step import OutputRef, StepDefinition, StepNode, step
+from clarifai.runners.pipelines.step import ExistingStepDefinition, OutputRef, StepDefinition, StepNode, step, step_ref
 
 __all__ = [
 	'ComputeConfig',
+	'ExistingStepDefinition',
 	'OutputRef',
 	'Pipeline',
 	'StepDefinition',
 	'StepNode',
 	'load_pipeline_from_file',
 	'step',
+	'step_ref',
 ]

--- a/clarifai/runners/pipelines/__init__.py
+++ b/clarifai/runners/pipelines/__init__.py
@@ -1,0 +1,13 @@
+from clarifai.runners.pipelines.compute import ComputeConfig
+from clarifai.runners.pipelines.pipeline import Pipeline, load_pipeline_from_file
+from clarifai.runners.pipelines.step import OutputRef, StepDefinition, StepNode, step
+
+__all__ = [
+	'ComputeConfig',
+	'OutputRef',
+	'Pipeline',
+	'StepDefinition',
+	'StepNode',
+	'load_pipeline_from_file',
+	'step',
+]

--- a/clarifai/runners/pipelines/codegen.py
+++ b/clarifai/runners/pipelines/codegen.py
@@ -1,11 +1,13 @@
 import ast
 import inspect
 import os
+import subprocess
 import textwrap
-from typing import Any, Dict, List, Sequence, Set
+from typing import List, Sequence, Set
 
 import yaml
 
+from clarifai.utils.logging import logger
 from clarifai.versions import CLIENT_VERSION
 
 
@@ -27,10 +29,30 @@ def _ensure_list_requirements(requirements) -> List[str]:
 
 
 def _get_node_source(source_lines: Sequence[str], node: ast.AST) -> str:
-    return ''.join(source_lines[node.lineno - 1:node.end_lineno])
+    return ''.join(source_lines[node.lineno - 1 : node.end_lineno])
 
 
-def _collect_helper_functions(tree: ast.Module, source_lines: Sequence[str], root_name: str) -> List[str]:
+# Modules that are only needed for the DSL definition, not at step runtime.
+_DSL_ONLY_MODULES = frozenset(
+    {
+        'clarifai.runners.pipelines',
+    }
+)
+
+
+def _is_dsl_only_import(node: ast.AST) -> bool:
+    """Return True if an import node pulls exclusively from DSL-only modules."""
+    if isinstance(node, ast.ImportFrom):
+        module = node.module or ''
+        return any(
+            module == prefix or module.startswith(prefix + '.') for prefix in _DSL_ONLY_MODULES
+        )
+    return False
+
+
+def _collect_helper_functions(
+    tree: ast.Module, source_lines: Sequence[str], root_name: str
+) -> List[str]:
     functions = {
         node.name: node
         for node in tree.body
@@ -39,7 +61,7 @@ def _collect_helper_functions(tree: ast.Module, source_lines: Sequence[str], roo
     imports = [
         _get_node_source(source_lines, node)
         for node in tree.body
-        if isinstance(node, (ast.Import, ast.ImportFrom))
+        if isinstance(node, (ast.Import, ast.ImportFrom)) and not _is_dsl_only_import(node)
     ]
 
     visited: Set[str] = set()
@@ -80,13 +102,20 @@ def _build_step_script(step_definition) -> str:
         module_source = handle.read()
     source_lines = module_source.splitlines(keepends=True)
     tree = ast.parse(module_source)
-    extracted_sources = _collect_helper_functions(tree, source_lines, step_definition.func.__name__)
-    function_source = '\n'.join(textwrap.dedent(block).rstrip() for block in extracted_sources if block.strip())
+    extracted_sources = _collect_helper_functions(
+        tree, source_lines, step_definition.func.__name__
+    )
+    function_source = '\n'.join(
+        textwrap.dedent(block).rstrip() for block in extracted_sources if block.strip()
+    )
 
     parser_lines = []
     call_args = []
     for param in step_definition.signature.parameters.values():
-        if param.kind not in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY):
+        if param.kind not in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        ):
             continue
         annotation = _annotation_to_argparse(param.annotation)
         required = param.default is inspect._empty
@@ -144,7 +173,27 @@ def generate_step_directory(step_definition, output_dir: str, user_id: str, app_
     with open(os.path.join(step_dir, 'requirements.txt'), 'w', encoding='utf-8') as handle:
         handle.write('\n'.join(_ensure_list_requirements(step_definition.requirements)) + '\n')
 
-    with open(os.path.join(version_dir, 'pipeline_step.py'), 'w', encoding='utf-8') as handle:
+    step_script_path = os.path.join(version_dir, 'pipeline_step.py')
+    with open(step_script_path, 'w', encoding='utf-8') as handle:
         handle.write(_build_step_script(step_definition))
 
+    _format_file(step_script_path)
+
     return step_dir
+
+
+def _format_file(path: str) -> None:
+    """Run ruff format on *path*, silently skipping if ruff is not available."""
+    try:
+        subprocess.run(
+            ['ruff', 'check', '--select', 'I', '--fix', '--quiet', path],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ['ruff', 'format', '--quiet', path],
+            check=True,
+            capture_output=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        logger.debug('ruff not available; skipping formatting of %s', path)

--- a/clarifai/runners/pipelines/codegen.py
+++ b/clarifai/runners/pipelines/codegen.py
@@ -1,0 +1,150 @@
+import ast
+import inspect
+import os
+import textwrap
+from typing import Any, Dict, List, Sequence, Set
+
+import yaml
+
+from clarifai.versions import CLIENT_VERSION
+
+
+def _ensure_list_requirements(requirements) -> List[str]:
+    if requirements is None:
+        entries = []
+    elif isinstance(requirements, str):
+        if os.path.exists(requirements):
+            with open(requirements, 'r', encoding='utf-8') as handle:
+                entries = [line.strip() for line in handle.readlines() if line.strip()]
+        else:
+            entries = [requirements]
+    else:
+        entries = [str(item).strip() for item in requirements if str(item).strip()]
+
+    if not any(entry.startswith('clarifai') for entry in entries):
+        entries.insert(0, f'clarifai=={CLIENT_VERSION}')
+    return entries
+
+
+def _get_node_source(source_lines: Sequence[str], node: ast.AST) -> str:
+    return ''.join(source_lines[node.lineno - 1:node.end_lineno])
+
+
+def _collect_helper_functions(tree: ast.Module, source_lines: Sequence[str], root_name: str) -> List[str]:
+    functions = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    imports = [
+        _get_node_source(source_lines, node)
+        for node in tree.body
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+    ]
+
+    visited: Set[str] = set()
+    ordered: List[str] = []
+
+    def visit(name: str):
+        node = functions.get(name)
+        if node is None or name in visited:
+            return
+        visited.add(name)
+        for child in ast.walk(node):
+            if isinstance(child, ast.Call) and isinstance(child.func, ast.Name):
+                called_name = child.func.id
+                if called_name != name:
+                    visit(called_name)
+        ordered.append(name)
+
+    visit(root_name)
+
+    helper_names = [name for name in ordered if name != root_name]
+    helper_sources = [_get_node_source(source_lines, functions[name]) for name in helper_names]
+    root_source = _get_node_source(source_lines, functions[root_name])
+    return imports + helper_sources + [root_source]
+
+
+def _annotation_to_argparse(annotation) -> str:
+    if annotation in (int, float, str):
+        return annotation.__name__
+    return 'str'
+
+
+def _build_step_script(step_definition) -> str:
+    source_file = inspect.getsourcefile(step_definition.func)
+    if source_file is None:
+        raise ValueError(f'Could not determine source file for step {step_definition.id}')
+
+    with open(source_file, 'r', encoding='utf-8') as handle:
+        module_source = handle.read()
+    source_lines = module_source.splitlines(keepends=True)
+    tree = ast.parse(module_source)
+    extracted_sources = _collect_helper_functions(tree, source_lines, step_definition.func.__name__)
+    function_source = '\n'.join(textwrap.dedent(block).rstrip() for block in extracted_sources if block.strip())
+
+    parser_lines = []
+    call_args = []
+    for param in step_definition.signature.parameters.values():
+        if param.kind not in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY):
+            continue
+        annotation = _annotation_to_argparse(param.annotation)
+        required = param.default is inspect._empty
+        default_line = '' if required else f", default={param.default!r}"
+        parser_lines.append(
+            f"    parser.add_argument('--{param.name}', type={annotation}, required={str(required)}{default_line}, help='Auto-generated parameter')"
+        )
+        call_args.append(f"{param.name}=args.{param.name}")
+
+    parser_block = '\n'.join(parser_lines) if parser_lines else '    pass'
+    call_block = ', '.join(call_args)
+
+    return (
+        "import argparse\n"
+        "import json\n\n"
+        f"{function_source}\n\n"
+        "def _serialize_output(value):\n"
+        "    if value is None:\n"
+        "        return None\n"
+        "    if isinstance(value, (dict, list)):\n"
+        "        return json.dumps(value)\n"
+        "    return str(value)\n\n"
+        "def main():\n"
+        f"    parser = argparse.ArgumentParser(description='{step_definition.id} processing step.')\n"
+        f"{parser_block}\n\n"
+        "    args = parser.parse_args()\n"
+        f"    result = {step_definition.func.__name__}({call_block})\n"
+        "    serialized = _serialize_output(result)\n"
+        "    if serialized is not None:\n"
+        "        print(serialized)\n\n"
+        "if __name__ == '__main__':\n"
+        "    main()\n"
+    )
+
+
+def generate_step_directory(step_definition, output_dir: str, user_id: str, app_id: str) -> str:
+    step_dir = os.path.join(output_dir, step_definition.id)
+    version_dir = os.path.join(step_dir, '1')
+    os.makedirs(version_dir, exist_ok=True)
+
+    config = {
+        'pipeline_step': {
+            'id': step_definition.id,
+            'user_id': user_id,
+            'app_id': app_id,
+        },
+        'pipeline_step_input_params': step_definition.get_input_params(),
+        'build_info': {'python_version': step_definition.python_version},
+        'pipeline_step_compute_info': step_definition.compute.to_dict(),
+    }
+
+    with open(os.path.join(step_dir, 'config.yaml'), 'w', encoding='utf-8') as handle:
+        yaml.safe_dump(config, handle, default_flow_style=False, sort_keys=False)
+
+    with open(os.path.join(step_dir, 'requirements.txt'), 'w', encoding='utf-8') as handle:
+        handle.write('\n'.join(_ensure_list_requirements(step_definition.requirements)) + '\n')
+
+    with open(os.path.join(version_dir, 'pipeline_step.py'), 'w', encoding='utf-8') as handle:
+        handle.write(_build_step_script(step_definition))
+
+    return step_dir

--- a/clarifai/runners/pipelines/codegen.py
+++ b/clarifai/runners/pipelines/codegen.py
@@ -6,6 +6,7 @@ import textwrap
 from typing import List, Sequence, Set
 
 import yaml
+from google.protobuf.json_format import MessageToDict
 
 from clarifai.utils.logging import logger
 from clarifai.versions import CLIENT_VERSION
@@ -164,7 +165,9 @@ def generate_step_directory(step_definition, output_dir: str, user_id: str, app_
         },
         'pipeline_step_input_params': step_definition.get_input_params(),
         'build_info': {'python_version': step_definition.python_version},
-        'pipeline_step_compute_info': step_definition.compute.to_dict(),
+        'pipeline_step_compute_info': MessageToDict(
+            step_definition.compute, preserving_proto_field_name=True
+        ),
     }
 
     with open(os.path.join(step_dir, 'config.yaml'), 'w', encoding='utf-8') as handle:

--- a/clarifai/runners/pipelines/codegen.py
+++ b/clarifai/runners/pipelines/codegen.py
@@ -9,7 +9,6 @@ import yaml
 from google.protobuf.json_format import MessageToDict
 
 from clarifai.utils.logging import logger
-from clarifai.versions import CLIENT_VERSION
 
 
 def _ensure_list_requirements(requirements) -> List[str]:
@@ -24,8 +23,6 @@ def _ensure_list_requirements(requirements) -> List[str]:
     else:
         entries = [str(item).strip() for item in requirements if str(item).strip()]
 
-    if not any(entry.startswith('clarifai') for entry in entries):
-        entries.insert(0, f'clarifai=={CLIENT_VERSION}')
     return entries
 
 

--- a/clarifai/runners/pipelines/compute.py
+++ b/clarifai/runners/pipelines/compute.py
@@ -1,14 +1,3 @@
-from dataclasses import asdict, dataclass
-from typing import Dict, Optional
+from clarifai_grpc.grpc.api.resources_pb2 import ComputeInfo
 
-
-@dataclass(frozen=True)
-class ComputeConfig:
-    """Compute requirements for an auto-generated pipeline step."""
-
-    cpu_limit: Optional[str] = None
-    cpu_memory: Optional[str] = None
-    num_accelerators: Optional[int] = None
-
-    def to_dict(self) -> Dict[str, object]:
-        return {key: value for key, value in asdict(self).items() if value is not None}
+__all__ = ['ComputeInfo']

--- a/clarifai/runners/pipelines/compute.py
+++ b/clarifai/runners/pipelines/compute.py
@@ -1,0 +1,14 @@
+from dataclasses import asdict, dataclass
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class ComputeConfig:
+    """Compute requirements for an auto-generated pipeline step."""
+
+    cpu_limit: Optional[str] = None
+    cpu_memory: Optional[str] = None
+    num_accelerators: Optional[int] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        return {key: value for key, value in asdict(self).items() if value is not None}

--- a/clarifai/runners/pipelines/pipeline.py
+++ b/clarifai/runners/pipelines/pipeline.py
@@ -1,0 +1,279 @@
+import importlib.util
+import os
+import tempfile
+from collections import OrderedDict
+from typing import Any, Dict, Iterable, List, Optional
+
+import yaml
+
+from clarifai.runners.pipelines.codegen import generate_step_directory
+from clarifai.runners.pipelines.step import OutputRef, StepDefinition, StepNode, WorkflowInputRef, _clear_active_pipeline, _set_active_pipeline
+
+
+class Pipeline:
+    """Code-first pipeline definition that compiles to the existing config format."""
+
+    def __init__(self, id: str, user_id: str, app_id: str, visibility: str = 'PRIVATE'):
+        self.id = id
+        self.user_id = user_id
+        self.app_id = app_id
+        self.visibility = visibility
+        self.nodes: List[StepNode] = []
+        self._node_names = set()
+        self._workflow_params = OrderedDict()
+        self._active = False
+        self._uploaded_pipeline_version_id: Optional[str] = None
+
+    def __enter__(self):
+        self._active = True
+        _set_active_pipeline(self)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        _clear_active_pipeline()
+        self._active = False
+        if exc_type is None:
+            self.validate()
+
+    def input(self, param_name: str, default: Any = None) -> WorkflowInputRef:
+        self._workflow_params[param_name] = default
+        return WorkflowInputRef(name=param_name)
+
+    def add_node(self, step_definition: StepDefinition, arguments: Dict[str, Any], name: Optional[str] = None) -> StepNode:
+        if not self._active:
+            raise RuntimeError('Pipeline nodes can only be created inside an active Pipeline context')
+
+        node_name = name or self._generate_task_name(step_definition.id)
+        node = StepNode(self, step_definition, node_name, arguments)
+        self.nodes.append(node)
+        self._node_names.add(node_name)
+
+        for value in arguments.values():
+            if isinstance(value, OutputRef):
+                self.add_dependency(value.node, node)
+            elif isinstance(value, WorkflowInputRef):
+                self._workflow_params.setdefault(value.name, None)
+
+        return node
+
+    def add_dependency(self, upstream, downstream):
+        for source in self._normalize_dependency_operand(upstream):
+            for target in self._normalize_dependency_operand(downstream):
+                if not isinstance(source, StepNode) or not isinstance(target, StepNode):
+                    raise TypeError('Dependencies must be StepNode instances')
+                target.dependencies.add(source.name)
+
+    def _normalize_dependency_operand(self, value) -> Iterable[StepNode]:
+        if isinstance(value, list):
+            return value
+        return [value]
+
+    def _generate_task_name(self, step_id: str) -> str:
+        candidate = step_id
+        suffix = 1
+        while candidate in self._node_names:
+            candidate = f'{step_id}-{suffix}'
+            suffix += 1
+        return candidate
+
+    def validate(self):
+        nodes_by_name = {node.name: node for node in self.nodes}
+        for node in self.nodes:
+            missing = [dependency for dependency in node.dependencies if dependency not in nodes_by_name]
+            if missing:
+                raise ValueError(f'Unknown dependencies for {node.name}: {missing}')
+
+        visited = set()
+        visiting = set()
+
+        def dfs(node: StepNode):
+            if node.name in visited:
+                return
+            if node.name in visiting:
+                raise ValueError(f'Cycle detected in pipeline graph at {node.name}')
+            visiting.add(node.name)
+            for dependency_name in node.dependencies:
+                dfs(nodes_by_name[dependency_name])
+            visiting.remove(node.name)
+            visited.add(node.name)
+
+        for node in self.nodes:
+            dfs(node)
+
+    def _serialize_argument_value(self, value: Any):
+        if isinstance(value, WorkflowInputRef):
+            return value.as_argo_value()
+        if isinstance(value, OutputRef):
+            return value.as_argo_value()
+        if isinstance(value, bool):
+            return 'true' if value else 'false'
+        return str(value)
+
+    def to_argo_spec(self) -> Dict[str, Any]:
+        self.validate()
+        parameters = []
+        for name, default in self._workflow_params.items():
+            item = {'name': name}
+            if default is not None:
+                item['value'] = str(default)
+            parameters.append(item)
+
+        tasks = []
+        for node in self.nodes:
+            task = {
+                'name': node.name,
+                'templateRef': {
+                    'name': f'users/{self.user_id}/apps/{self.app_id}/pipeline_steps/{node.step_definition.id}',
+                    'template': f'users/{self.user_id}/apps/{self.app_id}/pipeline_steps/{node.step_definition.id}',
+                },
+            }
+            if node.dependencies:
+                task['dependencies'] = sorted(node.dependencies)
+            if node.arguments:
+                task['arguments'] = {
+                    'parameters': [
+                        {'name': key, 'value': self._serialize_argument_value(value)}
+                        for key, value in node.arguments.items()
+                    ]
+                }
+            tasks.append(task)
+
+        return {
+            'apiVersion': 'argoproj.io/v1alpha1',
+            'kind': 'Workflow',
+            'spec': {
+                'entrypoint': self.id,
+                'arguments': {'parameters': parameters},
+                'templates': [
+                    {
+                        'name': self.id,
+                        'dag': {'tasks': tasks},
+                    }
+                ],
+            },
+        }
+
+    def to_config(self) -> Dict[str, Any]:
+        used_step_ids = []
+        seen = set()
+        step_version_secrets = {}
+        for node in self.nodes:
+            if node.step_definition.id not in seen:
+                used_step_ids.append(node.step_definition.id)
+                seen.add(node.step_definition.id)
+            if node.step_definition.secrets:
+                step_version_secrets[node.name] = node.step_definition.secrets
+
+        config = {
+            'pipeline': {
+                'id': self.id,
+                'user_id': self.user_id,
+                'app_id': self.app_id,
+                'visibility': {'gettable': self.visibility},
+                'step_directories': used_step_ids,
+                'orchestration_spec': {
+                    'argo_orchestration_spec': yaml.safe_dump(
+                        self.to_argo_spec(), default_flow_style=False, sort_keys=False
+                    )
+                },
+            }
+        }
+
+        if step_version_secrets:
+            config['pipeline']['config'] = {'step_version_secrets': step_version_secrets}
+
+        return config
+
+    def generate(self, output_dir: str) -> str:
+        os.makedirs(output_dir, exist_ok=True)
+        step_definitions = OrderedDict()
+        for node in self.nodes:
+            step_definitions.setdefault(node.step_definition.id, node.step_definition)
+
+        for step_definition in step_definitions.values():
+            generate_step_directory(step_definition, output_dir, self.user_id, self.app_id)
+
+        config_path = os.path.join(output_dir, 'config.yaml')
+        with open(config_path, 'w', encoding='utf-8') as handle:
+            yaml.safe_dump(self.to_config(), handle, default_flow_style=False, sort_keys=False)
+        return config_path
+
+    def upload(self, no_lockfile: bool = False) -> Optional[str]:
+        from clarifai.runners.pipelines.pipeline_builder import PipelineBuilder
+
+        temp_dir = tempfile.mkdtemp(prefix='clarifai-pipeline-')
+        config_path = self.generate(temp_dir)
+        builder = PipelineBuilder(config_path)
+        if not builder.ensure_app_exists():
+            raise RuntimeError('Failed to verify or create app for pipeline upload')
+        if not builder.upload_pipeline_steps():
+            raise RuntimeError('Failed to upload pipeline steps')
+        lockfile_data = None
+        if not no_lockfile:
+            lockfile_data = builder.prepare_lockfile_with_step_versions()
+        success, pipeline_version_id = builder.create_pipeline()
+        if not success:
+            raise RuntimeError('Failed to create pipeline')
+        if not no_lockfile and lockfile_data:
+            builder.save_lockfile(
+                builder.update_lockfile_with_pipeline_info(lockfile_data, pipeline_version_id)
+            )
+        self._uploaded_pipeline_version_id = pipeline_version_id
+        return pipeline_version_id
+
+    def run(
+        self,
+        inputs=None,
+        timeout: int = 3600,
+        monitor_interval: int = 10,
+        input_args_override=None,
+        nodepool_id: Optional[str] = None,
+        compute_cluster_id: Optional[str] = None,
+        log_file: Optional[str] = None,
+        base_url: Optional[str] = None,
+        pat: Optional[str] = None,
+        no_lockfile: bool = False,
+    ):
+        from clarifai.client.pipeline import Pipeline as PipelineClient
+
+        pipeline_version_id = self._uploaded_pipeline_version_id or self.upload(
+            no_lockfile=no_lockfile
+        )
+        client_kwargs = {
+            'pipeline_id': self.id,
+            'pipeline_version_id': pipeline_version_id,
+            'user_id': self.user_id,
+            'app_id': self.app_id,
+            'nodepool_id': nodepool_id,
+            'compute_cluster_id': compute_cluster_id,
+            'log_file': log_file,
+        }
+        if base_url is not None:
+            client_kwargs['base_url'] = base_url
+        if pat is not None:
+            client_kwargs['pat'] = pat
+
+        client = PipelineClient(**client_kwargs)
+        return client.run(
+            inputs=inputs,
+            timeout=timeout,
+            monitor_interval=monitor_interval,
+            input_args_override=input_args_override,
+        )
+
+
+def load_pipeline_from_file(file_path: str) -> Pipeline:
+    module_name = os.path.splitext(os.path.basename(file_path))[0]
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        raise ValueError(f'Could not load pipeline module from {file_path}')
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    pipelines = [value for value in module.__dict__.values() if isinstance(value, Pipeline)]
+    if not pipelines:
+        raise ValueError(f'No Pipeline instance found in {file_path}')
+    if len(pipelines) > 1:
+        raise ValueError(f'Multiple Pipeline instances found in {file_path}; expose only one')
+    return pipelines[0]

--- a/clarifai/runners/pipelines/pipeline.py
+++ b/clarifai/runners/pipelines/pipeline.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Iterable, List, Optional
 import yaml
 
 from clarifai.runners.pipelines.codegen import generate_step_directory
-from clarifai.runners.pipelines.step import OutputRef, StepDefinition, StepNode, WorkflowInputRef, _clear_active_pipeline, _set_active_pipeline
+from clarifai.runners.pipelines.step import OutputRef, StepNode, WorkflowInputRef, _clear_active_pipeline, _set_active_pipeline
 
 
 class Pipeline:
@@ -39,7 +39,7 @@ class Pipeline:
         self._workflow_params[param_name] = default
         return WorkflowInputRef(name=param_name)
 
-    def add_node(self, step_definition: StepDefinition, arguments: Dict[str, Any], name: Optional[str] = None) -> StepNode:
+    def add_node(self, step_definition, arguments: Dict[str, Any], name: Optional[str] = None) -> StepNode:
         if not self._active:
             raise RuntimeError('Pipeline nodes can only be created inside an active Pipeline context')
 
@@ -120,11 +120,12 @@ class Pipeline:
 
         tasks = []
         for node in self.nodes:
+            template_ref_name = node.step_definition.template_ref(self.user_id, self.app_id)
             task = {
                 'name': node.name,
                 'templateRef': {
-                    'name': f'users/{self.user_id}/apps/{self.app_id}/pipeline_steps/{node.step_definition.id}',
-                    'template': f'users/{self.user_id}/apps/{self.app_id}/pipeline_steps/{node.step_definition.id}',
+                    'name': template_ref_name,
+                    'template': template_ref_name,
                 },
             }
             if node.dependencies:
@@ -158,7 +159,7 @@ class Pipeline:
         seen = set()
         step_version_secrets = {}
         for node in self.nodes:
-            if node.step_definition.id not in seen:
+            if node.step_definition.is_managed and node.step_definition.id not in seen:
                 used_step_ids.append(node.step_definition.id)
                 seen.add(node.step_definition.id)
             if node.step_definition.secrets:
@@ -188,7 +189,8 @@ class Pipeline:
         os.makedirs(output_dir, exist_ok=True)
         step_definitions = OrderedDict()
         for node in self.nodes:
-            step_definitions.setdefault(node.step_definition.id, node.step_definition)
+            if node.step_definition.is_managed:
+                step_definitions.setdefault(node.step_definition.id, node.step_definition)
 
         for step_definition in step_definitions.values():
             generate_step_directory(step_definition, output_dir, self.user_id, self.app_id)

--- a/clarifai/runners/pipelines/pipeline.py
+++ b/clarifai/runners/pipelines/pipeline.py
@@ -238,25 +238,25 @@ class Pipeline:
     def upload(self, no_lockfile: bool = False) -> Optional[str]:
         from clarifai.runners.pipelines.pipeline_builder import PipelineBuilder
 
-        temp_dir = tempfile.mkdtemp(prefix='clarifai-pipeline-')
-        config_path = self.generate(temp_dir)
-        builder = PipelineBuilder(config_path)
-        if not builder.ensure_app_exists():
-            raise RuntimeError('Failed to verify or create app for pipeline upload')
-        if not builder.upload_pipeline_steps():
-            raise RuntimeError('Failed to upload pipeline steps')
-        lockfile_data = None
-        if not no_lockfile:
-            lockfile_data = builder.prepare_lockfile_with_step_versions()
-        success, pipeline_version_id = builder.create_pipeline()
-        if not success:
-            raise RuntimeError('Failed to create pipeline')
-        if not no_lockfile and lockfile_data:
-            builder.save_lockfile(
-                builder.update_lockfile_with_pipeline_info(lockfile_data, pipeline_version_id)
-            )
-        self._uploaded_pipeline_version_id = pipeline_version_id
-        return pipeline_version_id
+        with tempfile.TemporaryDirectory(prefix='clarifai-pipeline-') as temp_dir:
+            config_path = self.generate(temp_dir)
+            builder = PipelineBuilder(config_path)
+            if not builder.ensure_app_exists():
+                raise RuntimeError('Failed to verify or create app for pipeline upload')
+            if not builder.upload_pipeline_steps():
+                raise RuntimeError('Failed to upload pipeline steps')
+            lockfile_data = None
+            if not no_lockfile:
+                lockfile_data = builder.prepare_lockfile_with_step_versions()
+            success, pipeline_version_id = builder.create_pipeline()
+            if not success:
+                raise RuntimeError('Failed to create pipeline')
+            if not no_lockfile and lockfile_data:
+                builder.save_lockfile(
+                    builder.update_lockfile_with_pipeline_info(lockfile_data, pipeline_version_id)
+                )
+            self._uploaded_pipeline_version_id = pipeline_version_id
+            return pipeline_version_id
 
     def run(
         self,

--- a/clarifai/runners/pipelines/pipeline.py
+++ b/clarifai/runners/pipelines/pipeline.py
@@ -7,7 +7,13 @@ from typing import Any, Dict, Iterable, List, Optional
 import yaml
 
 from clarifai.runners.pipelines.codegen import generate_step_directory
-from clarifai.runners.pipelines.step import OutputRef, StepNode, WorkflowInputRef, _clear_active_pipeline, _set_active_pipeline
+from clarifai.runners.pipelines.step import (
+    OutputRef,
+    StepNode,
+    WorkflowInputRef,
+    _clear_active_pipeline,
+    _set_active_pipeline,
+)
 
 
 class Pipeline:
@@ -39,9 +45,13 @@ class Pipeline:
         self._workflow_params[param_name] = default
         return WorkflowInputRef(name=param_name)
 
-    def add_node(self, step_definition, arguments: Dict[str, Any], name: Optional[str] = None) -> StepNode:
+    def add_node(
+        self, step_definition, arguments: Dict[str, Any], name: Optional[str] = None
+    ) -> StepNode:
         if not self._active:
-            raise RuntimeError('Pipeline nodes can only be created inside an active Pipeline context')
+            raise RuntimeError(
+                'Pipeline nodes can only be created inside an active Pipeline context'
+            )
 
         node_name = name or self._generate_task_name(step_definition.id)
         node = StepNode(self, step_definition, node_name, arguments)
@@ -79,7 +89,9 @@ class Pipeline:
     def validate(self):
         nodes_by_name = {node.name: node for node in self.nodes}
         for node in self.nodes:
-            missing = [dependency for dependency in node.dependencies if dependency not in nodes_by_name]
+            missing = [
+                dependency for dependency in node.dependencies if dependency not in nodes_by_name
+            ]
             if missing:
                 raise ValueError(f'Unknown dependencies for {node.name}: {missing}')
 
@@ -109,6 +121,28 @@ class Pipeline:
             return 'true' if value else 'false'
         return str(value)
 
+    def _topological_layers(self) -> List[List[StepNode]]:
+        """Group nodes into layers where each layer's dependencies are satisfied by earlier layers."""
+        nodes_by_name = {node.name: node for node in self.nodes}
+        remaining = {node.name for node in self.nodes}
+        satisfied: set = set()
+        layers: List[List[StepNode]] = []
+
+        while remaining:
+            layer = [
+                nodes_by_name[name]
+                for name in sorted(remaining)
+                if nodes_by_name[name].dependencies <= satisfied
+            ]
+            if not layer:
+                raise ValueError('Cycle detected in pipeline graph')
+            for node in layer:
+                remaining.discard(node.name)
+                satisfied.add(node.name)
+            layers.append(layer)
+
+        return layers
+
     def to_argo_spec(self) -> Dict[str, Any]:
         self.validate()
         parameters = []
@@ -118,26 +152,27 @@ class Pipeline:
                 item['value'] = str(default)
             parameters.append(item)
 
-        tasks = []
-        for node in self.nodes:
-            template_ref_name = node.step_definition.template_ref(self.user_id, self.app_id)
-            task = {
-                'name': node.name,
-                'templateRef': {
-                    'name': template_ref_name,
-                    'template': template_ref_name,
-                },
-            }
-            if node.dependencies:
-                task['dependencies'] = sorted(node.dependencies)
-            if node.arguments:
-                task['arguments'] = {
-                    'parameters': [
-                        {'name': key, 'value': self._serialize_argument_value(value)}
-                        for key, value in node.arguments.items()
-                    ]
+        step_groups = []
+        for layer in self._topological_layers():
+            group = []
+            for node in layer:
+                template_ref_name = node.step_definition.template_ref(self.user_id, self.app_id)
+                step_entry = {
+                    'name': node.name,
+                    'templateRef': {
+                        'name': template_ref_name,
+                        'template': template_ref_name,
+                    },
                 }
-            tasks.append(task)
+                if node.arguments:
+                    step_entry['arguments'] = {
+                        'parameters': [
+                            {'name': key, 'value': self._serialize_argument_value(value)}
+                            for key, value in node.arguments.items()
+                        ]
+                    }
+                group.append(step_entry)
+            step_groups.append(group)
 
         return {
             'apiVersion': 'argoproj.io/v1alpha1',
@@ -148,7 +183,7 @@ class Pipeline:
                 'templates': [
                     {
                         'name': self.id,
-                        'dag': {'tasks': tasks},
+                        'steps': step_groups,
                     }
                 ],
             },

--- a/clarifai/runners/pipelines/pipeline_builder.py
+++ b/clarifai/runners/pipelines/pipeline_builder.py
@@ -389,59 +389,38 @@ class PipelineBuilder:
         The step versions should be resolved from the corresponding config-lock.yaml
         file of each pipeline-step, located in the step_directories.
         """
-        for template in argo_spec["spec"]["templates"]:
-            if "steps" in template:
-                for step_group in template["steps"]:
-                    for step in step_group:
-                        if "templateRef" in step:
-                            template_ref = step["templateRef"]
-                            name = template_ref["name"]
-                            # Extract step name
-                            parts = name.split('/')
+        for template_ref in self.validator.iter_template_refs(argo_spec):
+            name = template_ref["name"]
+            parts = name.split('/')
 
-                            # Check if this is a templateRef without version that we uploaded
-                            if self.validator.TEMPLATE_REF_WITHOUT_VERSION_PATTERN.match(name):
-                                step_name = parts[-1]
-                                # The step name should match the directory name or be derivable from it
-                                version_id = self.uploaded_step_versions.get(step_name, None)
+            if self.validator.TEMPLATE_REF_WITHOUT_VERSION_PATTERN.match(name):
+                step_name = parts[-1]
+                version_id = self.uploaded_step_versions.get(step_name, None)
+                if version_id is None:
+                    version_id = self._get_version_from_config_lock(step_name)
 
-                                # If not found in uploaded_step_versions, try to get from config-lock.yaml
-                                if version_id is None:
-                                    version_id = self._get_version_from_config_lock(step_name)
+                if version_id is not None:
+                    new_name = f"{name}/versions/{version_id}"
+                    template_ref["name"] = new_name
+                    template_ref["template"] = new_name
+                    logger.info(f"Updated templateRef from {name} to {new_name}")
+                else:
+                    logger.warning(f"Could not find version for step: {step_name}")
+            elif self.validator.TEMPLATE_REF_WITH_VERSION_PATTERN.match(name):
+                orig_name = name
+                name = orig_name.rsplit('/versions/', 1)[0]
+                step_name = parts[-3]
+                version_id = self.uploaded_step_versions.get(step_name, None)
+                if version_id is None:
+                    version_id = self._get_version_from_config_lock(step_name)
 
-                                if version_id is not None:
-                                    # Update the templateRef to include version
-                                    new_name = f"{name}/versions/{version_id}"
-                                    template_ref["name"] = new_name
-                                    template_ref["template"] = new_name
-                                    logger.info(f"Updated templateRef from {name} to {new_name}")
-                                else:
-                                    logger.warning(f"Could not find version for step: {step_name}")
-                            elif self.validator.TEMPLATE_REF_WITH_VERSION_PATTERN.match(name):
-                                # strip the /versions/{version_id} from the end of name
-                                # to get the name like above
-                                orig_name = name
-                                name = orig_name.rsplit('/versions/', 1)[0]
-                                step_name = parts[-3]  # Get the step name from the path
-
-                                # if it already has a version, make sure it matches the uploaded
-                                # version
-                                version_id = self.uploaded_step_versions.get(step_name, None)
-
-                                # If not found in uploaded_step_versions, try to get from config-lock.yaml
-                                if version_id is None:
-                                    version_id = self._get_version_from_config_lock(step_name)
-
-                                if version_id is not None:
-                                    # Update the templateRef to include version
-                                    new_name = f"{name}/versions/{version_id}"
-                                    template_ref["name"] = new_name
-                                    template_ref["template"] = new_name
-                                    logger.info(
-                                        f"Updated templateRef from {orig_name} to {new_name}"
-                                    )
-                                else:
-                                    logger.warning(f"Could not find version for step: {step_name}")
+                if version_id is not None:
+                    new_name = f"{name}/versions/{version_id}"
+                    template_ref["name"] = new_name
+                    template_ref["template"] = new_name
+                    logger.info(f"Updated templateRef from {orig_name} to {new_name}")
+                else:
+                    logger.warning(f"Could not find version for step: {step_name}")
 
     def _get_version_from_config_lock(self, step_name: str) -> str:
         """

--- a/clarifai/runners/pipelines/step.py
+++ b/clarifai/runners/pipelines/step.py
@@ -1,0 +1,135 @@
+import inspect
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+from clarifai.runners.pipelines.compute import ComputeConfig
+
+_ACTIVE_PIPELINE = threading.local()
+
+
+def _set_active_pipeline(pipeline):
+    _ACTIVE_PIPELINE.current = pipeline
+
+
+def _clear_active_pipeline():
+    _ACTIVE_PIPELINE.current = None
+
+
+def get_active_pipeline():
+    return getattr(_ACTIVE_PIPELINE, 'current', None)
+
+
+@dataclass(frozen=True)
+class WorkflowInputRef:
+    name: str
+
+    def as_argo_value(self) -> str:
+        return f"{{{{workflow.parameters.{self.name}}}}}"
+
+
+@dataclass(frozen=True)
+class OutputRef:
+    node: 'StepNode'
+    output_name: str = 'result'
+
+    def as_argo_value(self) -> str:
+        return f"{{{{tasks.{self.node.name}.outputs.parameters.{self.output_name}}}}}"
+
+
+class StepNode:
+    """A concrete task instance in a pipeline DAG."""
+
+    def __init__(self, pipeline, step_definition: 'StepDefinition', name: str, arguments: Dict[str, Any]):
+        self.pipeline = pipeline
+        self.step_definition = step_definition
+        self.name = name
+        self.arguments = arguments
+        self.dependencies = set()
+
+    def output(self, param_name: str = 'result') -> OutputRef:
+        return OutputRef(node=self, output_name=param_name)
+
+    def __rshift__(self, other):
+        self.pipeline.add_dependency(self, other)
+        return other
+
+    def __rrshift__(self, other):
+        if isinstance(other, list):
+            for item in other:
+                self.pipeline.add_dependency(item, self)
+            return self
+        raise TypeError(f"Unsupported dependency source: {type(other)!r}")
+
+
+class StepDefinition:
+    def __init__(
+        self,
+        func: Callable[..., Any],
+        *,
+        id: Optional[str] = None,
+        requirements=None,
+        compute: Optional[ComputeConfig] = None,
+        python_version: str = '3.12',
+        secrets: Optional[Dict[str, str]] = None,
+    ):
+        self.func = func
+        self.id = id or func.__name__.replace('_', '-')
+        self.requirements = requirements or []
+        self.compute = compute or ComputeConfig()
+        self.python_version = python_version
+        self.secrets = secrets or {}
+        self.signature = inspect.signature(func)
+
+    @property
+    def __name__(self):
+        return self.func.__name__
+
+    def __call__(self, *args, **kwargs):
+        pipeline = get_active_pipeline()
+        if pipeline is None:
+            return self.func(*args, **kwargs)
+
+        task_name = kwargs.pop('name', None)
+        bound = self.signature.bind_partial(*args, **kwargs)
+        bound.apply_defaults()
+        return pipeline.add_node(self, arguments=dict(bound.arguments), name=task_name)
+
+    def test(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
+
+    def get_input_params(self):
+        params = []
+        for param in self.signature.parameters.values():
+            if param.kind not in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY):
+                continue
+            param_config = {'name': param.name}
+            if param.default is not inspect._empty:
+                param_config['default'] = str(param.default)
+            annotation = param.annotation
+            if annotation is not inspect._empty:
+                annotation_name = getattr(annotation, '__name__', str(annotation))
+                param_config['description'] = f'Auto-generated from annotation {annotation_name}'
+            params.append(param_config)
+        return params
+
+
+def step(
+    *,
+    id: Optional[str] = None,
+    requirements=None,
+    compute: Optional[ComputeConfig] = None,
+    python_version: str = '3.12',
+    secrets: Optional[Dict[str, str]] = None,
+):
+    def decorator(func: Callable[..., Any]) -> StepDefinition:
+        return StepDefinition(
+            func,
+            id=id,
+            requirements=requirements,
+            compute=compute,
+            python_version=python_version,
+            secrets=secrets,
+        )
+
+    return decorator

--- a/clarifai/runners/pipelines/step.py
+++ b/clarifai/runners/pipelines/step.py
@@ -63,6 +63,8 @@ class StepNode:
 
 
 class StepDefinition:
+    is_managed = True
+
     def __init__(
         self,
         func: Callable[..., Any],
@@ -84,6 +86,9 @@ class StepDefinition:
     @property
     def __name__(self):
         return self.func.__name__
+
+    def template_ref(self, default_user_id: str, default_app_id: str) -> str:
+        return f'users/{default_user_id}/apps/{default_app_id}/pipeline_steps/{self.id}'
 
     def __call__(self, *args, **kwargs):
         pipeline = get_active_pipeline()
@@ -114,6 +119,55 @@ class StepDefinition:
         return params
 
 
+class ExistingStepDefinition:
+    is_managed = False
+
+    def __init__(
+        self,
+        *,
+        id: str,
+        version_id: str,
+        user_id: Optional[str] = None,
+        app_id: Optional[str] = None,
+        secrets: Optional[Dict[str, str]] = None,
+    ):
+        if not version_id:
+            raise ValueError('version_id is required for step_ref()')
+        self.id = id
+        self.version_id = version_id
+        self.user_id = user_id
+        self.app_id = app_id
+        self.secrets = secrets or {}
+
+    @property
+    def __name__(self):
+        return self.id.replace('-', '_')
+
+    def template_ref(self, default_user_id: str, default_app_id: str) -> str:
+        user_id = self.user_id or default_user_id
+        app_id = self.app_id or default_app_id
+        return (
+            f'users/{user_id}/apps/{app_id}/pipeline_steps/{self.id}/versions/{self.version_id}'
+        )
+
+    def __call__(self, *args, **kwargs):
+        pipeline = get_active_pipeline()
+        if pipeline is None:
+            raise RuntimeError('step_ref() instances can only be used inside an active Pipeline')
+
+        if args:
+            raise TypeError('step_ref() calls only support keyword arguments')
+
+        task_name = kwargs.pop('name', None)
+        return pipeline.add_node(self, arguments=dict(kwargs), name=task_name)
+
+    def test(self, *args, **kwargs):
+        raise RuntimeError('step_ref() does not support local execution')
+
+    def get_input_params(self):
+        return []
+
+
 def step(
     *,
     id: Optional[str] = None,
@@ -133,3 +187,20 @@ def step(
         )
 
     return decorator
+
+
+def step_ref(
+    *,
+    id: str,
+    version_id: str,
+    user_id: Optional[str] = None,
+    app_id: Optional[str] = None,
+    secrets: Optional[Dict[str, str]] = None,
+) -> ExistingStepDefinition:
+    return ExistingStepDefinition(
+        id=id,
+        version_id=version_id,
+        user_id=user_id,
+        app_id=app_id,
+        secrets=secrets,
+    )

--- a/clarifai/runners/pipelines/step.py
+++ b/clarifai/runners/pipelines/step.py
@@ -1,11 +1,33 @@
 import inspect
+import re
 import threading
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional
+from urllib.parse import urlparse
 
 from clarifai.runners.pipelines.compute import ComputeConfig
 
 _ACTIVE_PIPELINE = threading.local()
+_STEP_REF_URL_PATTERN = re.compile(
+    r'^users/(?P<user_id>[^/]+)/apps/(?P<app_id>[^/]+)/pipeline_steps/(?P<step_id>[^/]+)/versions/(?P<version_id>[^/]+)$'
+)
+
+
+def _parse_step_ref_url(step_url: str) -> Dict[str, str]:
+    parsed_url = urlparse(step_url)
+    resource_path = parsed_url.path if (parsed_url.scheme or parsed_url.netloc) else step_url
+    normalized_path = resource_path.strip('/')
+    if normalized_path.startswith('v2/'):
+        normalized_path = normalized_path[3:]
+
+    match = _STEP_REF_URL_PATTERN.match(normalized_path)
+    if match is None:
+        raise ValueError(
+            'step_ref.from_url() expects a versioned pipeline step URL or resource path of the form '
+            "'users/{user_id}/apps/{app_id}/pipeline_steps/{step_id}/versions/{version_id}'"
+        )
+
+    return match.groupdict()
 
 
 def _set_active_pipeline(pipeline):
@@ -122,6 +144,19 @@ class StepDefinition:
 class ExistingStepDefinition:
     is_managed = False
 
+    @classmethod
+    def from_url(
+        cls, step_url: str, *, secrets: Optional[Dict[str, str]] = None
+    ) -> 'ExistingStepDefinition':
+        parsed_step = _parse_step_ref_url(step_url)
+        return cls(
+            id=parsed_step['step_id'],
+            version_id=parsed_step['version_id'],
+            user_id=parsed_step['user_id'],
+            app_id=parsed_step['app_id'],
+            secrets=secrets,
+        )
+
     def __init__(
         self,
         *,
@@ -204,3 +239,12 @@ def step_ref(
         app_id=app_id,
         secrets=secrets,
     )
+
+
+def _step_ref_from_url(
+    step_url: str, *, secrets: Optional[Dict[str, str]] = None
+) -> ExistingStepDefinition:
+    return ExistingStepDefinition.from_url(step_url, secrets=secrets)
+
+
+step_ref.from_url = _step_ref_from_url

--- a/clarifai/runners/pipelines/step.py
+++ b/clarifai/runners/pipelines/step.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional
 from urllib.parse import urlparse
 
-from clarifai.runners.pipelines.compute import ComputeConfig
+from clarifai.runners.pipelines.compute import ComputeInfo
 
 _ACTIVE_PIPELINE = threading.local()
 _STEP_REF_URL_PATTERN = re.compile(
@@ -95,14 +95,14 @@ class StepDefinition:
         *,
         id: Optional[str] = None,
         requirements=None,
-        compute: Optional[ComputeConfig] = None,
+        compute: Optional[ComputeInfo] = None,
         python_version: str = '3.12',
         secrets: Optional[Dict[str, str]] = None,
     ):
         self.func = func
         self.id = id or func.__name__.replace('_', '-')
         self.requirements = requirements or []
-        self.compute = compute or ComputeConfig()
+        self.compute = compute or ComputeInfo()
         self.python_version = python_version
         self.secrets = secrets or {}
         self.signature = inspect.signature(func)
@@ -210,7 +210,7 @@ def step(
     *,
     id: Optional[str] = None,
     requirements=None,
-    compute: Optional[ComputeConfig] = None,
+    compute: Optional[ComputeInfo] = None,
     python_version: str = '3.12',
     secrets: Optional[Dict[str, str]] = None,
 ):

--- a/clarifai/runners/pipelines/step.py
+++ b/clarifai/runners/pipelines/step.py
@@ -120,7 +120,7 @@ class StepDefinition:
             return self.func(*args, **kwargs)
 
         task_name = kwargs.pop('name', None)
-        bound = self.signature.bind_partial(*args, **kwargs)
+        bound = self.signature.bind(*args, **kwargs)
         bound.apply_defaults()
         return pipeline.add_node(self, arguments=dict(bound.arguments), name=task_name)
 

--- a/clarifai/runners/pipelines/step.py
+++ b/clarifai/runners/pipelines/step.py
@@ -56,13 +56,15 @@ class OutputRef:
     output_name: str = 'result'
 
     def as_argo_value(self) -> str:
-        return f"{{{{tasks.{self.node.name}.outputs.parameters.{self.output_name}}}}}"
+        return f"{{{{steps.{self.node.name}.outputs.parameters.{self.output_name}}}}}"
 
 
 class StepNode:
     """A concrete task instance in a pipeline DAG."""
 
-    def __init__(self, pipeline, step_definition: 'StepDefinition', name: str, arguments: Dict[str, Any]):
+    def __init__(
+        self, pipeline, step_definition: 'StepDefinition', name: str, arguments: Dict[str, Any]
+    ):
         self.pipeline = pipeline
         self.step_definition = step_definition
         self.name = name
@@ -128,7 +130,10 @@ class StepDefinition:
     def get_input_params(self):
         params = []
         for param in self.signature.parameters.values():
-            if param.kind not in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY):
+            if param.kind not in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            ):
                 continue
             param_config = {'name': param.name}
             if param.default is not inspect._empty:
@@ -181,9 +186,7 @@ class ExistingStepDefinition:
     def template_ref(self, default_user_id: str, default_app_id: str) -> str:
         user_id = self.user_id or default_user_id
         app_id = self.app_id or default_app_id
-        return (
-            f'users/{user_id}/apps/{app_id}/pipeline_steps/{self.id}/versions/{self.version_id}'
-        )
+        return f'users/{user_id}/apps/{app_id}/pipeline_steps/{self.id}/versions/{self.version_id}'
 
     def __call__(self, *args, **kwargs):
         pipeline = get_active_pipeline()

--- a/clarifai/runners/utils/pipeline_validation.py
+++ b/clarifai/runners/utils/pipeline_validation.py
@@ -95,8 +95,15 @@ class PipelineConfigValidator:
         """Validate Argo workflow templates."""
         for template in templates:
             if "steps" in template:
-                for step_group in template["steps"]:
+                steps = template["steps"]
+                if not isinstance(steps, list):
+                    raise ValueError("'steps' in template must be a list")
+                for step_group in steps:
+                    if not isinstance(step_group, list):
+                        raise ValueError("each step group in 'steps' must be a list")
                     for step in step_group:
+                        if not isinstance(step, dict):
+                            raise ValueError("each step in a step group must be a dict")
                         if "templateRef" in step:
                             template_ref = step["templateRef"]
                             cls._validate_template_ref(template_ref)
@@ -104,7 +111,12 @@ class PipelineConfigValidator:
                 dag = template["dag"]
                 if not isinstance(dag, dict) or "tasks" not in dag:
                     raise ValueError("dag template must contain a 'tasks' field")
-                for task in dag["tasks"]:
+                tasks = dag["tasks"]
+                if not isinstance(tasks, list):
+                    raise ValueError("dag 'tasks' must be a list")
+                for task in tasks:
+                    if not isinstance(task, dict):
+                        raise ValueError("each item in dag 'tasks' must be a dict")
                     if "templateRef" in task:
                         template_ref = task["templateRef"]
                         cls._validate_template_ref(template_ref)

--- a/clarifai/runners/utils/pipeline_validation.py
+++ b/clarifai/runners/utils/pipeline_validation.py
@@ -100,6 +100,28 @@ class PipelineConfigValidator:
                         if "templateRef" in step:
                             template_ref = step["templateRef"]
                             cls._validate_template_ref(template_ref)
+            if "dag" in template:
+                dag = template["dag"]
+                if not isinstance(dag, dict) or "tasks" not in dag:
+                    raise ValueError("dag template must contain a 'tasks' field")
+                for task in dag["tasks"]:
+                    if "templateRef" in task:
+                        template_ref = task["templateRef"]
+                        cls._validate_template_ref(template_ref)
+
+    @classmethod
+    def iter_template_refs(cls, argo_spec: Dict[str, Any]):
+        """Yield templateRef dictionaries from either Argo steps or dag templates."""
+        for template in argo_spec.get("spec", {}).get("templates", []):
+            if "steps" in template:
+                for step_group in template["steps"]:
+                    for step in step_group:
+                        if "templateRef" in step:
+                            yield step["templateRef"]
+            if "dag" in template:
+                for task in template["dag"].get("tasks", []):
+                    if "templateRef" in task:
+                        yield task["templateRef"]
 
     @classmethod
     def _validate_template_ref(cls, template_ref: Dict[str, Any]) -> None:
@@ -134,20 +156,12 @@ class PipelineConfigValidator:
 
         steps_without_versions = []
 
-        for template in argo_spec["spec"]["templates"]:
-            if "steps" in template:
-                for step_group in template["steps"]:
-                    for step in step_group:
-                        if "templateRef" in step:
-                            template_ref = step["templateRef"]
-                            name = template_ref["name"]
-
-                            # Check if it's without version
-                            if cls.TEMPLATE_REF_WITHOUT_VERSION_PATTERN.match(name):
-                                # Extract step name
-                                parts = name.split('/')
-                                step_name = parts[-1]  # Last part is the step name
-                                if step_name not in steps_without_versions:
-                                    steps_without_versions.append(step_name)
+        for template_ref in cls.iter_template_refs(argo_spec):
+            name = template_ref["name"]
+            if cls.TEMPLATE_REF_WITHOUT_VERSION_PATTERN.match(name):
+                parts = name.split('/')
+                step_name = parts[-1]
+                if step_name not in steps_without_versions:
+                    steps_without_versions.append(step_name)
 
         return steps_without_versions

--- a/examples/pipeline_dsl_text_pipeline.py
+++ b/examples/pipeline_dsl_text_pipeline.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Example pipeline defined with the Clarifai pipeline DSL.
+
+This example demonstrates:
+- code-first step definitions with `@step`
+- helper-function extraction within a single step
+- diamond DAG composition using `>>`
+- step-level secret configuration
+- generation of the YAML/config-based pipeline bundle
+
+Usage:
+
+  python examples/pipeline_dsl_text_pipeline.py --generate ./generated-pipeline
+
+After generation, the resulting directory can be uploaded with either:
+
+  clarifai pipeline upload ./generated-pipeline
+
+or directly from this file:
+
+  clarifai pipeline upload examples/pipeline_dsl_text_pipeline.py
+"""
+
+import argparse
+
+from clarifai.runners.pipelines import ComputeConfig, Pipeline, step
+
+
+def normalize_text(value: str) -> str:
+    """Small helper intentionally kept outside the step for codegen extraction."""
+    return " ".join(value.strip().split())
+
+
+@step(
+    id="prepare-text",
+    requirements=["transformers>=4.0"],
+    compute=ComputeConfig(cpu_limit="500m", cpu_memory="500Mi"),
+)
+def prepare_text(input_text: str) -> str:
+    """Normalize text before downstream processing."""
+    cleaned = normalize_text(input_text)
+    return cleaned.lower()
+
+
+@step(
+    id="summarize",
+    requirements=["openai>=1.0"],
+    compute=ComputeConfig(cpu_limit="1000m", cpu_memory="1Gi", num_accelerators=1),
+    secrets={"OPENAI_API_KEY": "users/demo-user/secrets/openai-key"},
+)
+def summarize(input_text: str) -> str:
+    """Placeholder summary logic for the example pipeline."""
+    return f"Summary of: {input_text[:80]}"
+
+
+@step(id="classify-sentiment", requirements=["textblob>=0.18.0"])
+def classify_sentiment(input_text: str) -> str:
+    """A lightweight branch that simulates sentiment classification."""
+    positive_words = {"great", "good", "love", "excellent", "happy"}
+    tokens = set(input_text.split())
+    return "positive" if tokens & positive_words else "neutral"
+
+
+@step(id="assemble-report")
+def assemble_report(summary: str, sentiment: str) -> str:
+    """Join branch outputs into a single final payload."""
+    return f"Summary: {summary}\nSentiment: {sentiment}"
+
+
+with Pipeline(id="text-analysis-pipeline", user_id="demo-user", app_id="demo-app") as pipeline:
+    raw_text = pipeline.input("input_text")
+
+    prepared = prepare_text(input_text=raw_text)
+    summary = summarize(input_text=prepared.output())
+    sentiment = classify_sentiment(input_text=prepared.output())
+    report = assemble_report(
+        summary=summary.output(),
+        sentiment=sentiment.output(),
+    )
+
+    prepared >> [summary, sentiment] >> report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a code-first Clarifai pipeline bundle.")
+    parser.add_argument(
+        "--generate",
+        default="./generated-pipeline",
+        help="Directory where the generated pipeline bundle should be written.",
+    )
+    args = parser.parse_args()
+
+    config_path = pipeline.generate(args.generate)
+    print(f"Generated pipeline bundle at: {config_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/pipeline_dsl_text_pipeline.py
+++ b/examples/pipeline_dsl_text_pipeline.py
@@ -47,11 +47,8 @@ def prepare_text(input_text: str) -> str:
     return cleaned.lower()
 
 
-summarize = step_ref(
-    id="summarize",
-    user_id="demo-user",
-    app_id="shared-app",
-    version_id="summary-v1",
+summarize = step_ref.from_url(
+    "https://api.clarifai.com/v2/users/demo-user/apps/shared-app/pipeline_steps/summarize/versions/summary-v1",
     secrets={"OPENAI_API_KEY": "users/demo-user/secrets/openai-key"},
 )
 

--- a/examples/pipeline_dsl_text_pipeline.py
+++ b/examples/pipeline_dsl_text_pipeline.py
@@ -28,7 +28,7 @@ not included in `step_directories`.
 
 import argparse
 
-from clarifai.runners.pipelines import ComputeConfig, Pipeline, step, step_ref
+from clarifai.runners.pipelines import ComputeInfo, Pipeline, step, step_ref
 
 
 def normalize_text(value: str) -> str:
@@ -39,7 +39,7 @@ def normalize_text(value: str) -> str:
 @step(
     id="prepare-text",
     requirements=["transformers>=4.0"],
-    compute=ComputeConfig(cpu_limit="500m", cpu_memory="500Mi"),
+    compute=ComputeInfo(cpu_limit="500m", cpu_memory="500Mi"),
 )
 def prepare_text(input_text: str) -> str:
     """Normalize text before downstream processing."""

--- a/examples/pipeline_dsl_text_pipeline.py
+++ b/examples/pipeline_dsl_text_pipeline.py
@@ -3,6 +3,7 @@
 
 This example demonstrates:
 - code-first step definitions with `@step`
+- mixed local and pre-existing remote steps
 - helper-function extraction within a single step
 - diamond DAG composition using `>>`
 - step-level secret configuration
@@ -19,11 +20,15 @@ After generation, the resulting directory can be uploaded with either:
 or directly from this file:
 
   clarifai pipeline upload examples/pipeline_dsl_text_pipeline.py
+
+Only locally managed steps are generated into the bundle. Pre-existing steps
+declared with `step_ref(...)` are emitted as versioned `templateRef`s and are
+not included in `step_directories`.
 """
 
 import argparse
 
-from clarifai.runners.pipelines import ComputeConfig, Pipeline, step
+from clarifai.runners.pipelines import ComputeConfig, Pipeline, step, step_ref
 
 
 def normalize_text(value: str) -> str:
@@ -42,23 +47,21 @@ def prepare_text(input_text: str) -> str:
     return cleaned.lower()
 
 
-@step(
+summarize = step_ref(
     id="summarize",
-    requirements=["openai>=1.0"],
-    compute=ComputeConfig(cpu_limit="1000m", cpu_memory="1Gi", num_accelerators=1),
+    user_id="demo-user",
+    app_id="shared-app",
+    version_id="summary-v1",
     secrets={"OPENAI_API_KEY": "users/demo-user/secrets/openai-key"},
 )
-def summarize(input_text: str) -> str:
-    """Placeholder summary logic for the example pipeline."""
-    return f"Summary of: {input_text[:80]}"
 
 
-@step(id="classify-sentiment", requirements=["textblob>=0.18.0"])
-def classify_sentiment(input_text: str) -> str:
-    """A lightweight branch that simulates sentiment classification."""
-    positive_words = {"great", "good", "love", "excellent", "happy"}
-    tokens = set(input_text.split())
-    return "positive" if tokens & positive_words else "neutral"
+classify_sentiment = step_ref(
+    id="classify-sentiment",
+    user_id="demo-user",
+    app_id="shared-app",
+    version_id="sentiment-v3",
+)
 
 
 @step(id="assemble-report")

--- a/tests/cli/test_pipeline_dsl_cli.py
+++ b/tests/cli/test_pipeline_dsl_cli.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-from click.testing import CliRunner
 import yaml
+from click.testing import CliRunner
 
 from clarifai.cli.pipeline import generate, upload
 

--- a/tests/cli/test_pipeline_dsl_cli.py
+++ b/tests/cli/test_pipeline_dsl_cli.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from clarifai.cli.pipeline import generate, upload
+
+
+def test_upload_python_pipeline_file_uses_pipeline_loader(tmp_path: Path):
+    pipeline_file = tmp_path / 'pipeline_def.py'
+    pipeline_file.write_text('pipeline = None\n', encoding='utf-8')
+    runner = CliRunner()
+
+    with patch('clarifai.runners.pipelines.load_pipeline_from_file') as mock_loader:
+        mock_pipeline = Mock()
+        mock_loader.return_value = mock_pipeline
+
+        result = runner.invoke(upload, [str(pipeline_file)])
+
+    assert result.exit_code == 0
+    mock_loader.assert_called_once_with(str(pipeline_file))
+    mock_pipeline.upload.assert_called_once_with(no_lockfile=False)
+
+
+def test_generate_python_pipeline_file_writes_output(tmp_path: Path):
+    pipeline_file = tmp_path / 'pipeline_def.py'
+    pipeline_file.write_text('pipeline = None\n', encoding='utf-8')
+    output_dir = tmp_path / 'generated'
+    runner = CliRunner()
+
+    with patch('clarifai.runners.pipelines.load_pipeline_from_file') as mock_loader:
+        mock_pipeline = Mock()
+        mock_pipeline.generate.return_value = str(output_dir / 'config.yaml')
+        mock_loader.return_value = mock_pipeline
+
+        result = runner.invoke(generate, [str(pipeline_file), '--output-dir', str(output_dir)])
+
+    assert result.exit_code == 0
+    mock_loader.assert_called_once_with(str(pipeline_file))
+    mock_pipeline.generate.assert_called_once_with(str(output_dir))

--- a/tests/cli/test_pipeline_dsl_cli.py
+++ b/tests/cli/test_pipeline_dsl_cli.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from click.testing import CliRunner
+import yaml
 
 from clarifai.cli.pipeline import generate, upload
 
@@ -38,3 +39,26 @@ def test_generate_python_pipeline_file_writes_output(tmp_path: Path):
     assert result.exit_code == 0
     mock_loader.assert_called_once_with(str(pipeline_file))
     mock_pipeline.generate.assert_called_once_with(str(output_dir))
+
+
+def test_generate_real_example_pipeline_writes_mixed_step_config(tmp_path: Path):
+    repo_root = Path(__file__).resolve().parents[2]
+    pipeline_file = repo_root / 'examples' / 'pipeline_dsl_text_pipeline.py'
+    output_dir = tmp_path / 'generated'
+    runner = CliRunner()
+
+    result = runner.invoke(generate, [str(pipeline_file), '--output-dir', str(output_dir)])
+
+    assert result.exit_code == 0, result.output
+
+    config = yaml.safe_load((output_dir / 'config.yaml').read_text(encoding='utf-8'))
+    argo_spec = yaml.safe_load(config['pipeline']['orchestration_spec']['argo_orchestration_spec'])
+    tasks = {
+        task['name']: task for task in argo_spec['spec']['templates'][0]['dag']['tasks']
+    }
+
+    assert config['pipeline']['step_directories'] == ['prepare-text', 'assemble-report']
+    assert tasks['summarize']['templateRef']['name'].endswith('/versions/summary-v1')
+    assert tasks['classify-sentiment']['templateRef']['name'].endswith('/versions/sentiment-v3')
+    assert not (output_dir / 'summarize').exists()
+    assert not (output_dir / 'classify-sentiment').exists()

--- a/tests/cli/test_pipeline_dsl_cli.py
+++ b/tests/cli/test_pipeline_dsl_cli.py
@@ -7,20 +7,26 @@ import yaml
 from clarifai.cli.pipeline import generate, upload
 
 
-def test_upload_python_pipeline_file_uses_pipeline_loader(tmp_path: Path):
+def test_upload_python_pipeline_file_generates_and_uploads_directory(tmp_path: Path):
     pipeline_file = tmp_path / 'pipeline_def.py'
     pipeline_file.write_text('pipeline = None\n', encoding='utf-8')
     runner = CliRunner()
 
-    with patch('clarifai.runners.pipelines.load_pipeline_from_file') as mock_loader:
+    with (
+        patch('clarifai.runners.pipelines.load_pipeline_from_file') as mock_loader,
+        patch('clarifai.runners.pipelines.pipeline_builder.upload_pipeline') as mock_upload,
+    ):
         mock_pipeline = Mock()
+        mock_pipeline.id = 'test-pipeline'
         mock_loader.return_value = mock_pipeline
 
         result = runner.invoke(upload, [str(pipeline_file)])
 
+    expected_dir = str(tmp_path / 'generated-test-pipeline')
     assert result.exit_code == 0
     mock_loader.assert_called_once_with(str(pipeline_file))
-    mock_pipeline.upload.assert_called_once_with(no_lockfile=False)
+    mock_pipeline.generate.assert_called_once_with(expected_dir)
+    mock_upload.assert_called_once_with(expected_dir, no_lockfile=False)
 
 
 def test_generate_python_pipeline_file_writes_output(tmp_path: Path):
@@ -53,9 +59,8 @@ def test_generate_real_example_pipeline_writes_mixed_step_config(tmp_path: Path)
 
     config = yaml.safe_load((output_dir / 'config.yaml').read_text(encoding='utf-8'))
     argo_spec = yaml.safe_load(config['pipeline']['orchestration_spec']['argo_orchestration_spec'])
-    tasks = {
-        task['name']: task for task in argo_spec['spec']['templates'][0]['dag']['tasks']
-    }
+    step_groups = argo_spec['spec']['templates'][0]['steps']
+    tasks = {entry['name']: entry for group in step_groups for entry in group}
 
     assert config['pipeline']['step_directories'] == ['prepare-text', 'assemble-report']
     assert tasks['summarize']['templateRef']['name'].endswith('/versions/summary-v1')

--- a/tests/runners/test_pipeline_dsl.py
+++ b/tests/runners/test_pipeline_dsl.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import pytest
 import yaml
 
-from clarifai.runners.pipelines import ComputeConfig, Pipeline, step
+from clarifai.runners.pipelines import ComputeConfig, Pipeline, step, step_ref
 from clarifai.runners.utils.pipeline_validation import PipelineConfigValidator
 
 
@@ -20,18 +21,21 @@ def prepare_text(input_text: str) -> str:
     return normalize_text(input_text)
 
 
-@step(
+summarize = step_ref(
     id='summarize',
-    requirements=['openai>=1.0'],
+    user_id='me',
+    app_id='shared-app',
+    version_id='summary-v1',
     secrets={'OPENAI_API_KEY': 'users/me/secrets/openai-key'},
 )
-def summarize(input_text: str) -> str:
-    return f'summary:{input_text}'
 
 
-@step(id='classify-sentiment')
-def classify_sentiment(input_text: str) -> str:
-    return 'positive'
+classify_sentiment = step_ref(
+    id='classify-sentiment',
+    user_id='me',
+    app_id='shared-app',
+    version_id='sentiment-v2',
+)
 
 
 @step(id='assemble-report')
@@ -75,9 +79,18 @@ def test_pipeline_to_config_supports_diamond_dag_and_secrets():
     assert tasks['classify-sentiment']['dependencies'] == ['prepare-text']
     assert tasks['assemble-report']['dependencies'] == ['classify-sentiment', 'summarize']
     assert (
+        tasks['summarize']['templateRef']['name']
+        == 'users/me/apps/shared-app/pipeline_steps/summarize/versions/summary-v1'
+    )
+    assert (
+        tasks['classify-sentiment']['templateRef']['name']
+        == 'users/me/apps/shared-app/pipeline_steps/classify-sentiment/versions/sentiment-v2'
+    )
+    assert (
         tasks['summarize']['arguments']['parameters'][0]['value']
         == '{{tasks.prepare-text.outputs.parameters.result}}'
     )
+    assert config['pipeline']['step_directories'] == ['prepare-text', 'assemble-report']
     assert config['pipeline']['config']['step_version_secrets'] == {
         'summarize': {'OPENAI_API_KEY': 'users/me/secrets/openai-key'}
     }
@@ -103,14 +116,16 @@ def test_pipeline_generate_writes_helper_functions_and_expected_files(tmp_path: 
     assert '@step' not in step_script_content
     assert 'clarifai==' in requirements_content
     assert 'transformers>=4.0' in requirements_content
+    assert not (tmp_path / 'summarize').exists()
+    assert not (tmp_path / 'classify-sentiment').exists()
 
 
-def test_validator_collects_unversioned_steps_from_dag_config():
+def test_validator_collects_only_managed_steps_without_versions():
     pipeline = build_pipeline()
 
     steps = PipelineConfigValidator.get_pipeline_steps_without_versions(pipeline.to_config())
 
-    assert steps == ['prepare-text', 'summarize', 'classify-sentiment', 'assemble-report']
+    assert steps == ['prepare-text', 'assemble-report']
 
 
 def test_pipeline_run_uploads_then_delegates_to_client():
@@ -141,3 +156,8 @@ def test_pipeline_run_uploads_then_delegates_to_client():
         monitor_interval=3,
         input_args_override=None,
     )
+
+
+def test_step_ref_is_not_callable_outside_pipeline():
+    with pytest.raises(RuntimeError, match='active Pipeline'):
+        summarize(input_text='hello')

--- a/tests/runners/test_pipeline_dsl.py
+++ b/tests/runners/test_pipeline_dsl.py
@@ -21,11 +21,8 @@ def prepare_text(input_text: str) -> str:
     return normalize_text(input_text)
 
 
-summarize = step_ref(
-    id='summarize',
-    user_id='me',
-    app_id='shared-app',
-    version_id='summary-v1',
+summarize = step_ref.from_url(
+    'users/me/apps/shared-app/pipeline_steps/summarize/versions/summary-v1',
     secrets={'OPENAI_API_KEY': 'users/me/secrets/openai-key'},
 )
 
@@ -161,3 +158,21 @@ def test_pipeline_run_uploads_then_delegates_to_client():
 def test_step_ref_is_not_callable_outside_pipeline():
     with pytest.raises(RuntimeError, match='active Pipeline'):
         summarize(input_text='hello')
+
+
+def test_step_ref_from_url_parses_versioned_pipeline_step_url():
+    step_definition = step_ref.from_url(
+        'https://api.clarifai.com/v2/users/demo-user/apps/shared-app/pipeline_steps/summarize/versions/summary-v1',
+        secrets={'OPENAI_API_KEY': 'users/demo-user/secrets/openai-key'},
+    )
+
+    assert step_definition.id == 'summarize'
+    assert step_definition.user_id == 'demo-user'
+    assert step_definition.app_id == 'shared-app'
+    assert step_definition.version_id == 'summary-v1'
+    assert step_definition.secrets == {'OPENAI_API_KEY': 'users/demo-user/secrets/openai-key'}
+
+
+def test_step_ref_from_url_requires_versioned_pipeline_step_path():
+    with pytest.raises(ValueError, match='versioned pipeline step URL or resource path'):
+        step_ref.from_url('users/demo-user/apps/shared-app/pipeline_steps/summarize')

--- a/tests/runners/test_pipeline_dsl.py
+++ b/tests/runners/test_pipeline_dsl.py
@@ -61,9 +61,9 @@ def test_pipeline_to_config_supports_diamond_dag_and_secrets():
     PipelineConfigValidator.validate_config(config)
 
     argo_spec = yaml.safe_load(config['pipeline']['orchestration_spec']['argo_orchestration_spec'])
-    tasks = {
-        task['name']: task for task in argo_spec['spec']['templates'][0]['dag']['tasks']
-    }
+    step_groups = argo_spec['spec']['templates'][0]['steps']
+    # Flatten into a name→entry map for easy assertions
+    tasks = {entry['name']: entry for group in step_groups for entry in group}
 
     assert set(tasks) == {
         'prepare-text',
@@ -71,10 +71,11 @@ def test_pipeline_to_config_supports_diamond_dag_and_secrets():
         'classify-sentiment',
         'assemble-report',
     }
-    assert 'dependencies' not in tasks['prepare-text']
-    assert tasks['summarize']['dependencies'] == ['prepare-text']
-    assert tasks['classify-sentiment']['dependencies'] == ['prepare-text']
-    assert tasks['assemble-report']['dependencies'] == ['classify-sentiment', 'summarize']
+    # Verify layer ordering: prepare-text before summarize/sentiment, both before assemble-report
+    layer_names = [sorted(entry['name'] for entry in group) for group in step_groups]
+    assert layer_names[0] == ['prepare-text']
+    assert layer_names[1] == ['classify-sentiment', 'summarize']
+    assert layer_names[2] == ['assemble-report']
     assert (
         tasks['summarize']['templateRef']['name']
         == 'users/me/apps/shared-app/pipeline_steps/summarize/versions/summary-v1'
@@ -85,7 +86,7 @@ def test_pipeline_to_config_supports_diamond_dag_and_secrets():
     )
     assert (
         tasks['summarize']['arguments']['parameters'][0]['value']
-        == '{{tasks.prepare-text.outputs.parameters.result}}'
+        == '{{steps.prepare-text.outputs.parameters.result}}'
     )
     assert config['pipeline']['step_directories'] == ['prepare-text', 'assemble-report']
     assert config['pipeline']['config']['step_version_secrets'] == {

--- a/tests/runners/test_pipeline_dsl.py
+++ b/tests/runners/test_pipeline_dsl.py
@@ -112,7 +112,6 @@ def test_pipeline_generate_writes_helper_functions_and_expected_files(tmp_path: 
 
     assert 'def normalize_text(value: str) -> str:' in step_script_content
     assert '@step' not in step_script_content
-    assert 'clarifai==' in requirements_content
     assert 'transformers>=4.0' in requirements_content
     assert not (tmp_path / 'summarize').exists()
     assert not (tmp_path / 'classify-sentiment').exists()

--- a/tests/runners/test_pipeline_dsl.py
+++ b/tests/runners/test_pipeline_dsl.py
@@ -1,0 +1,143 @@
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import yaml
+
+from clarifai.runners.pipelines import ComputeConfig, Pipeline, step
+from clarifai.runners.utils.pipeline_validation import PipelineConfigValidator
+
+
+def normalize_text(value: str) -> str:
+    return ' '.join(value.strip().split())
+
+
+@step(
+    id='prepare-text',
+    requirements=['transformers>=4.0'],
+    compute=ComputeConfig(cpu_limit='500m', cpu_memory='500Mi'),
+)
+def prepare_text(input_text: str) -> str:
+    return normalize_text(input_text)
+
+
+@step(
+    id='summarize',
+    requirements=['openai>=1.0'],
+    secrets={'OPENAI_API_KEY': 'users/me/secrets/openai-key'},
+)
+def summarize(input_text: str) -> str:
+    return f'summary:{input_text}'
+
+
+@step(id='classify-sentiment')
+def classify_sentiment(input_text: str) -> str:
+    return 'positive'
+
+
+@step(id='assemble-report')
+def assemble_report(summary: str, sentiment: str) -> str:
+    return f'{summary}:{sentiment}'
+
+
+def build_pipeline() -> Pipeline:
+    with Pipeline(id='text-pipeline', user_id='me', app_id='my-app') as pipeline:
+        raw_text = pipeline.input('input_text')
+        prepared = prepare_text(input_text=raw_text)
+        summary = summarize(input_text=prepared.output())
+        sentiment = classify_sentiment(input_text=prepared.output())
+        report = assemble_report(
+            summary=summary.output(),
+            sentiment=sentiment.output(),
+        )
+        prepared >> [summary, sentiment] >> report
+    return pipeline
+
+
+def test_pipeline_to_config_supports_diamond_dag_and_secrets():
+    pipeline = build_pipeline()
+
+    config = pipeline.to_config()
+    PipelineConfigValidator.validate_config(config)
+
+    argo_spec = yaml.safe_load(config['pipeline']['orchestration_spec']['argo_orchestration_spec'])
+    tasks = {
+        task['name']: task for task in argo_spec['spec']['templates'][0]['dag']['tasks']
+    }
+
+    assert set(tasks) == {
+        'prepare-text',
+        'summarize',
+        'classify-sentiment',
+        'assemble-report',
+    }
+    assert 'dependencies' not in tasks['prepare-text']
+    assert tasks['summarize']['dependencies'] == ['prepare-text']
+    assert tasks['classify-sentiment']['dependencies'] == ['prepare-text']
+    assert tasks['assemble-report']['dependencies'] == ['classify-sentiment', 'summarize']
+    assert (
+        tasks['summarize']['arguments']['parameters'][0]['value']
+        == '{{tasks.prepare-text.outputs.parameters.result}}'
+    )
+    assert config['pipeline']['config']['step_version_secrets'] == {
+        'summarize': {'OPENAI_API_KEY': 'users/me/secrets/openai-key'}
+    }
+
+
+def test_pipeline_generate_writes_helper_functions_and_expected_files(tmp_path: Path):
+    pipeline = build_pipeline()
+
+    config_path = Path(pipeline.generate(str(tmp_path)))
+
+    assert config_path.exists()
+    assert (tmp_path / 'prepare-text' / 'config.yaml').exists()
+    assert (tmp_path / 'prepare-text' / 'requirements.txt').exists()
+    step_script = tmp_path / 'prepare-text' / '1' / 'pipeline_step.py'
+    assert step_script.exists()
+
+    step_script_content = step_script.read_text(encoding='utf-8')
+    requirements_content = (tmp_path / 'prepare-text' / 'requirements.txt').read_text(
+        encoding='utf-8'
+    )
+
+    assert 'def normalize_text(value: str) -> str:' in step_script_content
+    assert '@step' not in step_script_content
+    assert 'clarifai==' in requirements_content
+    assert 'transformers>=4.0' in requirements_content
+
+
+def test_validator_collects_unversioned_steps_from_dag_config():
+    pipeline = build_pipeline()
+
+    steps = PipelineConfigValidator.get_pipeline_steps_without_versions(pipeline.to_config())
+
+    assert steps == ['prepare-text', 'summarize', 'classify-sentiment', 'assemble-report']
+
+
+def test_pipeline_run_uploads_then_delegates_to_client():
+    pipeline = build_pipeline()
+
+    with patch.object(pipeline, 'upload', return_value='pipeline-version-123') as mock_upload:
+        with patch('clarifai.client.pipeline.Pipeline') as mock_client_class:
+            mock_client = Mock()
+            mock_client.run.return_value = {'status': 'ok'}
+            mock_client_class.return_value = mock_client
+
+            result = pipeline.run(timeout=12, monitor_interval=3)
+
+    assert result == {'status': 'ok'}
+    mock_upload.assert_called_once_with(no_lockfile=False)
+    mock_client_class.assert_called_once_with(
+        pipeline_id='text-pipeline',
+        pipeline_version_id='pipeline-version-123',
+        user_id='me',
+        app_id='my-app',
+        nodepool_id=None,
+        compute_cluster_id=None,
+        log_file=None,
+    )
+    mock_client.run.assert_called_once_with(
+        inputs=None,
+        timeout=12,
+        monitor_interval=3,
+        input_args_override=None,
+    )

--- a/tests/runners/test_pipeline_dsl.py
+++ b/tests/runners/test_pipeline_dsl.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 import yaml
 
-from clarifai.runners.pipelines import ComputeConfig, Pipeline, step, step_ref
+from clarifai.runners.pipelines import ComputeInfo, Pipeline, step, step_ref
 from clarifai.runners.utils.pipeline_validation import PipelineConfigValidator
 
 
@@ -15,7 +15,7 @@ def normalize_text(value: str) -> str:
 @step(
     id='prepare-text',
     requirements=['transformers>=4.0'],
-    compute=ComputeConfig(cpu_limit='500m', cpu_memory='500Mi'),
+    compute=ComputeInfo(cpu_limit='500m', cpu_memory='500Mi'),
 )
 def prepare_text(input_text: str) -> str:
     return normalize_text(input_text)


### PR DESCRIPTION
## Summary

This PR adds a Python-first DSL for defining Clarifai pipelines and generating the existing config-based pipeline assets from code.

Users can now define managed steps with `@step`, reference existing remote steps with `step_ref(...)` / `step_ref.from_url(...)`, compose execution order inside a `Pipeline(...)` context, and then either:

- generate a config bundle with `clarifai pipeline generate <pipeline.py>`
- upload directly from the Python definition with `clarifai pipeline upload <pipeline.py>`

Refer this example of the new authoring experience: `examples/pipeline_dsl_text_pipeline.py`

## What Changed

- Added a new pipeline DSL under `clarifai.runners.pipelines`
- Added `ComputeConfig`, `StepDefinition`, `ExistingStepDefinition`, `StepNode`, `OutputRef`, `step`, `step_ref`, and `Pipeline`
- Added support for loading a pipeline from a Python file and generating config/step directories from it
- Added CLI support for Python pipeline definitions in `clarifai pipeline generate` and `clarifai pipeline upload`
- Added `step_ref.from_url(...)` for versioned pipeline step URLs/resource paths
- Switched generated Argo orchestration output to `steps` format so it matches the existing config-based path and backend expectations
- Updated codegen to:
  - extract helper functions used by steps
  - filter out DSL-only imports from generated step code
  - run `ruff` import-fix + formatting on generated pipeline_step.py
- Extended pipeline validation to handle both `steps` and `dag` template traversal
- Added example coverage and DSL-focused tests

## Why

This improves pipeline authoring UX without changing the downstream upload/build path. The Python DSL compiles back into the same config-based artifacts already used by `PipelineBuilder`, so users get a code-centric authoring model while keeping the existing deployment flow.

## Validation

- `python -m pytest test_pipeline_dsl.py test_pipeline_dsl_cli.py -v`
- Verified Python pipeline generation writes expected config and step assets
- Verified direct CLI upload from `.py` generates a sibling pipeline directory and writes config-lock.yaml there
- Verified end-to-end generate/upload/run flow separately with a research-agent pipeline using the new DSL

## Notes

- Only locally managed `@step` definitions are emitted into `step_directories`
- Remote `step_ref(...)` steps are emitted as versioned `templateRef`s and are not generated locally