### PR TITLE
validate private HuggingFace repos with token   

### DIFF
--- a/clarifai/runners/models/model_builder.py
+++ b/clarifai/runners/models/model_builder.py
@@ -692,8 +692,9 @@ class ModelBuilder:
                 if has_access:
                     # Public repo — no token needed anywhere.
                     pass
-                elif reason == "gated_no_token":
-                    # Repo requires auth. Validate with the available token.
+                elif reason in ("gated_no_token", "not_found"):
+                    # Repo requires auth (gated) or is private (returns not_found
+                    # to anonymous requests). Validate with the available token.
                     if is_valid_token:
                         has_access, reason = HuggingFaceLoader.validate_hf_repo_access(
                             repo_id=repo_id,

--- a/tests/runners/test_model_deploy.py
+++ b/tests/runners/test_model_deploy.py
@@ -2198,7 +2198,11 @@ class TestHFTokenValidation:
                     ModelBuilder(str(target), validate_api_ids=False)
 
     def test_validate_config_not_found_raises(self):
-        """ModelBuilder raises UserError with 'not found' for missing repo."""
+        """Anonymous 'not_found' with no valid token → asks for authentication
+        (since HF returns not_found for both missing and private repos when
+        unauthenticated, we can't tell them apart without a token).
+        When a valid token is provided and the repo is truly missing, the
+        'not found' error is raised."""
         import shutil
         from pathlib import Path
         from unittest.mock import patch
@@ -2224,6 +2228,7 @@ class TestHFTokenValidation:
             with config_path.open("w") as f:
                 yaml.dump(config, f, sort_keys=False)
 
+            # No token: not_found → prompt for authentication.
             with (
                 patch(
                     "clarifai.runners.utils.loader.HuggingFaceLoader.validate_hf_repo_access",
@@ -2232,6 +2237,23 @@ class TestHFTokenValidation:
                 patch(
                     "clarifai.runners.utils.loader.HuggingFaceLoader.validate_hftoken",
                     return_value=False,
+                ),
+            ):
+                with pytest.raises(UserError, match="requires authentication"):
+                    ModelBuilder(str(target), validate_api_ids=False)
+
+            # With a valid token that still sees the repo as not_found → "not found".
+            config["checkpoints"]["hf_token"] = "hf_valid_token"
+            with config_path.open("w") as f:
+                yaml.dump(config, f, sort_keys=False)
+            with (
+                patch(
+                    "clarifai.runners.utils.loader.HuggingFaceLoader.validate_hf_repo_access",
+                    side_effect=[(False, "not_found"), (False, "not_found")],
+                ),
+                patch(
+                    "clarifai.runners.utils.loader.HuggingFaceLoader.validate_hftoken",
+                    return_value=True,
                 ),
             ):
                 with pytest.raises(UserError, match="not found"):
@@ -2367,6 +2389,49 @@ class TestHFTokenValidation:
                 ModelBuilder(str(target), validate_api_ids=False)
                 # 1st anonymous, 2nd with config token
                 assert mv.call_count == 2
+                assert mv.call_args_list[1].kwargs["token"] == "hf_config_token"
+
+    def test_validate_config_private_repo_retries_with_token(self):
+        """Private (non-gated) HF repos return 'not_found' to anonymous requests;
+        validation must retry with the configured token instead of failing."""
+        import shutil
+        from pathlib import Path
+        from unittest.mock import patch
+
+        tests_dir = Path(__file__).parent.resolve()
+        original_dummy_path = tests_dir / "dummy_runner_models"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "test_model"
+            shutil.copytree(original_dummy_path, target)
+
+            config_path = target / "config.yaml"
+            with config_path.open("r") as f:
+                config = yaml.safe_load(f)
+
+            config["checkpoints"] = {
+                "type": "huggingface",
+                "repo_id": "some-user/private-repo",
+                "hf_token": "hf_config_token",
+                "when": "runtime",
+            }
+            with config_path.open("w") as f:
+                yaml.dump(config, f, sort_keys=False)
+
+            # 1st call (anonymous) → not_found (private repo), 2nd (with token) → success
+            mock_validate = patch(
+                "clarifai.runners.utils.loader.HuggingFaceLoader.validate_hf_repo_access",
+                side_effect=[(False, "not_found"), (True, "")],
+            )
+            mock_hftoken = patch(
+                "clarifai.runners.utils.loader.HuggingFaceLoader.validate_hftoken",
+                return_value=True,
+            )
+
+            with mock_validate as mv, mock_hftoken:
+                ModelBuilder(str(target), validate_api_ids=False)
+                assert mv.call_count == 2
+                assert mv.call_args_list[0].kwargs["token"] is False
                 assert mv.call_args_list[1].kwargs["token"] == "hf_config_token"
 
 


### PR DESCRIPTION
  The two-step HF validation added in #960 (2026-03-04) does an anonymous probe first, then retries with the  
  user's token only when the reason is "gated_no_token". But HuggingFace returns RepositoryNotFoundError →
  "not_found" for private repos to anonymous callers (to avoid leaking their existence), so private repos     
  never got the retry and failed with a misleading "not found" error — even when the user had a valid token
  with access.                                                                                                
                                                                                                              
  This PR expands the retry branch to also handle "not_found", so private HF repos resolve correctly via      
  HF_TOKEN or checkpoints.hf_token. Truly missing repos still raise the "not found" error once the
  token-authenticated probe also fails. Updated one existing test and added a new                             
  test_validate_config_private_repo_retries_with_token to cover the private-repo path.
