### PR TITLE
Disable deploy_latest_version for model serve

### DIFF
--- a/clarifai/cli/model.py
+++ b/clarifai/cli/model.py
@@ -2265,7 +2265,7 @@ def serve_cmd(
                                 },
                             }
                         ],
-                        "deploy_latest_version": True,
+                        "deploy_latest_version": False,
                         "visibility": {
                             "gettable": app_visibility.gettable,
                         },


### PR DESCRIPTION
## Summary
- Set `deploy_latest_version` to `False` when creating deployments via `clarifai model serve`
- The `True` default caused a race condition: deployment auto-updates to a new version before the runner registers, resulting in "model is deploying" errors even though the runner is ready
- This was particularly problematic for local runners where `clarifai model serve` creates a new version + runner in the same session

## Test plan
- [ ] Run `clarifai model serve` on a model — verify deployment is created with `deploy_latest_version=false`
- [ ] Run `clarifai model serve` again after changing method signatures — verify new version is created and deployment is updated correctly
- [ ] Verify existing deployments with `deploy_latest_version=true` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)