### PR TITLE
Add pip package ecosystem to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly" # You can change this to "daily" if you prefer
+    open-pull-requests-limit: 10
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
This PR adds a Dependabot configuration file to automate dependency updates for the Python ecosystem. 

## Changes
- Created `.github/dependabot.yml`.
- Configured weekly checks for `pip` dependencies.
- Added a grouping rule to bundle updates into a single PR (to avoid notification noise).

## Why?
Keeping dependencies like `requests`, `numpy`, and `tqdm` up to date manually is time-consuming. Dependabot will now automatically alert us and provide PRs when new versions are released, helping us stay secure and use the latest features.

## How to test
Once merged, you can verify the status under the **Insights > Dependency graph > Dependabot** tab.