### PR TITLE
Add ruff to test dependencies

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,4 +9,5 @@ pypdf==3.17.4
 seaborn==0.13.2
 pycocotools>=2.0.7
 rich>=13.4.2
+ruff>=0.11.0
 pydantic==2.11.7


### PR DESCRIPTION
## Summary
Add `ruff` to `tests/requirements.txt` so it's available in the CI test environment.

## Why
`model_builder._lint_python_code()` calls `shutil.which('ruff')` and raises if not found. Ruff was only installed via pre-commit (separate virtualenv), not in the test environment. This caused `test_model_deploy`, `test_model_upload`, and `test_vllm_model_upload` to fail with "ruff command not found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)