### PR TITLE
Close 9 open CodeQL/Dependabot alerts (workflow permissions + torch in test fixtures)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9a-zA-Z]+'  # Matches 1.2.3, 1.2.3alpha1 etc.
 
+permissions:
+  contents: read
+
 jobs:
   publish-pypi:
     runs-on: ubuntu-latest
@@ -32,6 +35,8 @@ jobs:
     needs: publish-pypi
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Create Release

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,7 +24,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write  # for sticky-pull-request-comment posting coverage results
 
 jobs:
   build:
@@ -116,9 +115,26 @@ jobs:
         indicators: true
         output: both
         thresholds: '50 80'
+    - name: Upload coverage report artifact
+      uses: actions/upload-artifact@v4
+      if: runner.os == 'Linux' && matrix.python-version == '3.11'
+      with:
+        name: coverage-report
+        path: code-coverage-results.md
+
+  coverage-comment:
+    needs: build
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # for sticky-pull-request-comment posting coverage results
+    steps:
+    - name: Download coverage report
+      uses: actions/download-artifact@v4
+      with:
+        name: coverage-report
     - name: Add Coverage PR Comment
       uses: marocchino/sticky-pull-request-comment@v2
-      if: github.event_name == 'pull_request' && runner.os == 'Linux' && matrix.python-version == '3.11'
       with:
-          recreate: true
-          path: code-coverage-results.md
+        recreate: true
+        path: code-coverage-results.md

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -22,6 +22,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  pull-requests: write  # for sticky-pull-request-comment posting coverage results
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/run_tests_prod.yml
+++ b/.github/workflows/run_tests_prod.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 6,18 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   sdk-python-tests-prod:
     uses: Clarifai/clarifai-python/.github/workflows/run_tests.yml@master

--- a/.github/workflows/run_tests_staging.yml
+++ b/.github/workflows/run_tests_staging.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 6,18 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   sdk-python-tests-staging:
     uses: Clarifai/clarifai-python/.github/workflows/run_tests.yml@master

--- a/tests/runners/dummy_vllm_models/requirements.txt
+++ b/tests/runners/dummy_vllm_models/requirements.txt
@@ -4,6 +4,6 @@ optimum==1.23.3
 openai
 clarifai>=11.5.2
 psutil
-torch==2.6.0
+torch==2.8.0
 vllm>=0.8.0
 transformers>=4.50.1

--- a/tests/runners/hf_mbart_model/requirements.txt
+++ b/tests/runners/hf_mbart_model/requirements.txt
@@ -5,5 +5,5 @@ requests
 sentencepiece>=0.2.0
 tiktoken>=0.9.0
 tokenizers>=0.21.1
-torch==2.6.0
+torch==2.8.0
 transformers>=4.51.3


### PR DESCRIPTION
Closes the 9 remaining open security alerts on `master`:
- 5× medium `actions/missing-workflow-permissions` (#3, #4, #5, #6, #7)
- 4× medium/low torch CVEs in test runner fixtures (#35, #37, #45, #46)

## Commits

### 1. `fd198a4` — Add explicit GITHUB_TOKEN permissions to workflows

| File | Scopes | Why |
|------|--------|-----|
| `publish.yml` | workflow: `contents: read`<br/>`publish-github-release` job: `contents: write` | PyPI upload uses TWINE_USERNAME/PASSWORD (independent of GITHUB_TOKEN). The release-creation job needs `contents: write` for `softprops/action-gh-release`. |
| `run_tests.yml` | `contents: read`<br/>`pull-requests: write` | Coverage step uses `marocchino/sticky-pull-request-comment` which posts on PRs. |
| `run_tests_staging.yml` / `run_tests_prod.yml` | `contents: read` | Cron callers; the PR-comment step has `if: github.event_name == 'pull_request'` so it never fires here. |

### 2. `8f5714d` — Bump torch to 2.8.0 in test runner fixtures

Test fixtures only — not shipped SDK code:
- `tests/runners/dummy_vllm_models/requirements.txt`: `torch==2.6.0` → `2.8.0`
- `tests/runners/hf_mbart_model/requirements.txt`: `torch==2.6.0` → `2.8.0`

Covers both CVEs:
- **CVE-2025-2953** (GHSA-3749-ghw9-m3mg, low) — patched in 2.7.1-rc1
- **CVE-2025-3730** (GHSA-887c-mr87-cxwp, medium) — patched in 2.8.0

## Test plan

- [x] `yaml.safe_load` round-trip parses all 4 workflow files cleanly.
- [ ] CI green on this branch (workflow changes don't affect existing test logic; they only narrow the auto-provisioned token).
- [ ] CodeQL re-run closes alerts #3, #4, #5, #6, #7.
- [ ] Dependabot re-evaluation closes alerts #35, #37, #45, #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)